### PR TITLE
[Feat] 회원 엔티티 및 VO 추가

### DIFF
--- a/src/main/java/org/pgsg/user_service/user/domain/entity/ChatTimeRange.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/entity/ChatTimeRange.java
@@ -1,0 +1,33 @@
+package org.pgsg.user_service.user.domain.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatTimeRange {
+
+	@Column(name = "day_of_week", nullable = false)
+	private DayOfWeek dayOfWeek;
+
+	// 요일별 채팅가능 시간이므로 날짜 정보 없이 시간만 저장
+	@Column(name = "start_time", nullable = false)
+	private LocalTime startTime;
+
+	@Column(name = "end_time", nullable = false)
+	private LocalTime endTime;
+
+	public static ChatTimeRange of(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+		return new ChatTimeRange(dayOfWeek, startTime, endTime);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/domain/entity/User.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/entity/User.java
@@ -1,0 +1,73 @@
+package org.pgsg.user_service.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+// TODO: 공통모듈 배포 시 BaseEntity 상속
+@Getter
+@Table(
+		name = "p_user",
+		uniqueConstraints = {
+				@UniqueConstraint(
+						name = "uk_user_user_info",
+						columnNames = {"username", "name", "nickname"}
+				)
+		}
+)
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "user_id")
+	private UUID userId;
+
+	@Column(name = "username", length = 12, nullable = false)
+	private String username;
+
+	@Column(name = "password", nullable = false)
+	private String password;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "user_role", nullable = false)
+	private UserRole userRole;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	@ElementCollection(fetch = FetchType.LAZY)
+	@CollectionTable(name = "p_chat_time_range", joinColumns = @JoinColumn(name = "user_id"))
+	private List<ChatTimeRange> chatTimeRange = new ArrayList<>();
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private User(String username, String password, UserRole userRole, String name, String nickname) {
+		this.username = username;
+		this.password = password;
+		this.userRole = userRole;
+		this.name = name;
+		this.nickname = nickname;
+	}
+
+	public static User create(String username, String encryptedPassword, UserRole userRole, String name, String nickname) {
+		return User.builder()
+				.username(username)
+				.password(encryptedPassword)
+				.userRole(userRole)
+				.name(name)
+				.nickname(nickname)
+				.build();
+	}
+
+	// TODO: 채팅가능시간 관련 세부 로직 추가(인증 로직 구현 이후 회원 관련 기능 구현 시)
+}

--- a/src/main/java/org/pgsg/user_service/user/domain/entity/UserRole.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/entity/UserRole.java
@@ -1,0 +1,21 @@
+package org.pgsg.user_service.user.domain.entity;
+
+import java.util.Arrays;
+
+public enum UserRole {
+
+	USER,
+	MANAGER,
+	MASTER;
+
+	public String getRole() {
+		return "ROLE_" + this.name();
+	}
+
+	public static UserRole find(String userRole) {
+		return Arrays.stream(UserRole.values())
+				.filter(role -> role.getRole().equals(userRole))
+				.findAny()
+				.orElseThrow(() -> new IllegalArgumentException("해당하는 회원권한을 찾을 수 없습니다."));	// 현재는 임시로 IllegalArgumentException 사용, 커스텀 예외 클래스 추가 시 교체 예정
+	}
+}


### PR DESCRIPTION
### 작업 배경
- JWT 토큰 발급 및 인증 기능 구현에 필요한 요소 추가

### 작업 내용
- 회원 엔티티 추가
  - username, name, nickname 관련 복합 unique 제약조건 추가 
- 채팅가능시간대 vo 추가
- 회원권한 vo 추가
- 엔티티/vo 내 정적 팩토리 메서드 추가

### 테스트 여부

- 현재 회원 엔티티와 그 내부에서 사용되는 vo 클래스를 추가하는 정도로만 작업을 진행했기 때문에 테스트는 아직 진행하지 않았습니다.

### 기타

- 현재 인증 기능 구현에 필요한 기능 위주로 회원 도메인의 엔티티와 VO의 도메인 로직을 추가했기 때문에, 아직 구현되지 않은 도메인 로직은 인증 기능 구현 완료 이후 추가할 예정입니다.

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)

- This closes #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 사용자 계정 및 프로필 관리 시스템 기반 구축 (역할 기반 권한 제어 및 인증 기능 포함)
* 사용자가 요일별로 채팅 가능한 시간대를 설정하고 관리할 수 있는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->