### PR TITLE
feat : 토큰 저장 및 만료 부분 구현

### DIFF
--- a/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
@@ -1,0 +1,18 @@
+package org.pgsg.user_service.auth.domain;
+
+import org.pgsg.user_service.auth.domain.vo.TokenPair;
+
+public interface JwtTokenProvider {
+
+    // 사용자 식별값과 권한 정보를 바탕으로 토큰 생성
+    TokenPair createTokenPair(String userId, String role);
+
+    // 토큰에서 사용자 식별값(Subject) 추출
+    String getUserId(String token);
+
+    // 토큰 유효성 및 만료 여부 확인
+    boolean validateToken(String token);
+
+    // 만료된 토큰에서도 클레임을 추출 (재발급 로직용)
+    String getUserIdFromExpiredToken(String token);
+}

--- a/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
@@ -1,11 +1,14 @@
 package org.pgsg.user_service.auth.domain;
 
 import org.pgsg.user_service.auth.domain.vo.TokenPair;
+import org.pgsg.user_service.user.domain.entity.UserRole;
+
+import java.util.UUID;
 
 public interface JwtTokenProvider {
 
     // 사용자 식별값과 권한 정보를 바탕으로 토큰 생성
-    TokenPair createTokenPair(String userId, String role);
+    TokenPair createTokenPair(UUID userId, UserRole role);
 
     // 토큰에서 사용자 식별값(Subject) 추출
     String getUserId(String token);

--- a/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
@@ -17,5 +17,5 @@ public interface JwtTokenProvider {
     boolean validateToken(String token);
 
     // 만료된 토큰에서도 클레임을 추출 (재발급 로직용)
-    String getUserIdFromExpiredToken(String token);
+    String getSubjectFromExpiredAccessToken(String accessToken);
 }

--- a/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/JwtTokenProvider.java
@@ -11,7 +11,7 @@ public interface JwtTokenProvider {
     TokenPair createTokenPair(UUID userId, UserRole role);
 
     // 토큰에서 사용자 식별값(Subject) 추출
-    String getUserId(String token);
+    UUID getUserId(String token);
 
     // 토큰 유효성 및 만료 여부 확인
     boolean validateToken(String token);

--- a/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
@@ -2,18 +2,19 @@ package org.pgsg.user_service.auth.domain;
 
 import java.util.Optional;
 import java.time.Duration;
+import java.util.UUID;
 
 public interface TokenRepository {
 
     // 토큰 저장
-    void saveRefreshToken(String userId, String refreshToken, Duration duration);
+    void saveRefreshToken(String userId, String refreshTokenHash, Duration duration);
 
     // 저장된 토큰 조회
-    Optional<String> findRefreshToken(String userId);
+    Optional<String> findRefreshTokenHash(String userId);
 
     // 로그아웃 또는 토큰 갱신 시 삭제
-    void deleteRefreshToken(String userId);
+    void deleteRefreshToken(UUID userId);
 
     // 특정 토큰 존재 여부 확인
-    boolean existsByRefreshToken(String refreshToken);
+    boolean existsByRefreshTokenHash(String refreshTokenHash);
 }

--- a/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
@@ -1,0 +1,19 @@
+package org.pgsg.user_service.auth.domain;
+
+import java.util.Optional;
+import java.time.Duration;
+
+public interface TokenRepository {
+
+    // 토큰 저장
+    void saveRefreshToken(String userId, String refreshToken, Duration duration);
+
+    // 저장된 토큰 조회
+    Optional<String> findRefreshToken(String userId);
+
+    // 로그아웃 또는 토큰 갱신 시 삭제
+    void deleteRefreshToken(String userId);
+
+    // 특정 토큰 존재 여부 확인
+    boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/TokenRepository.java
@@ -7,10 +7,10 @@ import java.util.UUID;
 public interface TokenRepository {
 
     // 토큰 저장
-    void saveRefreshToken(String userId, String refreshTokenHash, Duration duration);
+    void saveRefreshToken(UUID userId, String refreshTokenHash, Duration duration);
 
     // 저장된 토큰 조회
-    Optional<String> findRefreshTokenHash(String userId);
+    Optional<String> findRefreshTokenHash(UUID userId);
 
     // 로그아웃 또는 토큰 갱신 시 삭제
     void deleteRefreshToken(UUID userId);

--- a/src/main/java/org/pgsg/user_service/auth/domain/vo/TokenPair.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/vo/TokenPair.java
@@ -1,0 +1,17 @@
+package org.pgsg.user_service.auth.domain.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenPair {
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long accessTokenExpiresIn;
+
+    public static TokenPair of(String accessToken, String refreshToken, Long expiresIn) {
+        return new TokenPair(accessToken, refreshToken, expiresIn);
+    }
+}

--- a/src/main/java/org/pgsg/user_service/auth/domain/vo/TokenPair.java
+++ b/src/main/java/org/pgsg/user_service/auth/domain/vo/TokenPair.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TokenPair {
@@ -12,6 +14,19 @@ public class TokenPair {
     private final Long accessTokenExpiresIn;
 
     public static TokenPair of(String accessToken, String refreshToken, Long expiresIn) {
+        Objects.requireNonNull(accessToken, "액세스 토큰은 null일 수 없습니다.");
+        Objects.requireNonNull(refreshToken, "리프레시 토큰은 null일 수 없습니다.");
+        Objects.requireNonNull(expiresIn, "만료 시간은 null일 수 없습니다.");
+
+        // 빈 문자열 및 공백 체크
+        if (accessToken.isBlank() || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("토큰 값은 비어 있거나 공백일 수 없습니다.");
+        }
+        // 시간 유효성 체크
+        if (expiresIn <= 0) {
+            throw new IllegalArgumentException("만료 시간은 0보다 커야 합니다.");
+        }
+
         return new TokenPair(accessToken, refreshToken, expiresIn);
     }
 }


### PR DESCRIPTION
### 작업 배경
- jwt 기본 설정

### 작업 내용
- accessToken + refreshToken VO 작성
-  기본 JwtToken 서비스 작성 및 레포 작성

### 테스트 여부
- 추후 통합 후 테스트 예정입니다.
### 기타
- 기능 구현 위주로 개발하여 추후 방식으로 리팩토링할 예정입니다. 

### 이슈
> closes #5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * JWT 액세스/리프레시 토큰 쌍 생성 및 만료된 액세스 토큰에서 식별자/주체를 추출하는 기능 추가.
  * 토큰 쌍(액세스·리프레시·만료정보) 표현 도입으로 인증 토큰 처리가 명확해짐.

* **개선 사항**
  * 리프레시 토큰 저장·조회·삭제와 해시 존재 확인 기능을 일관되게 제공하여 토큰 수명 관리 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->