### PR TITLE
[Feat] 회원가입 기능 구현

### DIFF
--- a/src/main/java/org/pgsg/user_service/auth/application/dto/command/SignupUserCommand.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/dto/command/SignupUserCommand.java
@@ -1,0 +1,19 @@
+package org.pgsg.user_service.auth.application.dto.command;
+
+import org.pgsg.user_service.user.application.dto.command.CreateChatTimeCommand;
+import org.pgsg.user_service.user.domain.model.UserRole;
+
+import java.util.List;
+
+/**
+ * Auth 서비스 내에서 회원가입 로직 처리를 담당하는 Command 객체
+ */
+public record SignupUserCommand(
+        String username,
+        String password,
+        UserRole userRole,
+        String name,
+        String nickname,
+        List<CreateChatTimeCommand> chatTimeRanges
+) {
+}

--- a/src/main/java/org/pgsg/user_service/auth/application/dto/info/SignupInfo.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/dto/info/SignupInfo.java
@@ -1,0 +1,22 @@
+package org.pgsg.user_service.auth.application.dto.info;
+
+import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
+
+import java.util.UUID;
+
+// Auth 도메인 내에서 가입 완료 정보를 전달하기 위한 전용 Info DTO
+public record SignupInfo(
+		UUID userId,
+		String username,
+		String nickname
+		// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+) {
+	public static SignupInfo from(UserDetailInfo userInfo) {
+		return new SignupInfo(
+				userInfo.userId(),
+				userInfo.username(),
+				userInfo.nickname()
+				// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+		);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
@@ -31,6 +31,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     //로그인 기능
+    @Transactional
     public AuthInfo login(LoginUserCommand command) {
 
         LoginUserDetailInfo userDetail = userService.getUser(command.getUsername());
@@ -46,6 +47,7 @@ public class AuthService {
     }
 
     //로그아웃 기능
+    @Transactional
     public void logout(UUID userId) {
         tokenRepository.deleteRefreshToken(userId);
     }

--- a/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.pgsg.user_service.auth.application.dto.command.LoginUserCommand;
 import org.pgsg.user_service.auth.application.dto.command.SignupUserCommand;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
+import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
 import org.pgsg.user_service.auth.domain.JwtTokenProvider;
 import org.pgsg.user_service.auth.domain.TokenRepository;
 import org.pgsg.user_service.auth.domain.UserAuthenticator;
@@ -11,6 +12,7 @@ import org.pgsg.user_service.auth.domain.model.TokenPair;
 import org.pgsg.user_service.user.application.UserService;
 import org.pgsg.user_service.user.application.dto.command.CreateUserCommand;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
+import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +51,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void signup(SignupUserCommand command) {
+    public SignupInfo signup(SignupUserCommand command) {
         String encryptedPassword = passwordEncoder.encode(command.password());
         CreateUserCommand createUserCommand = new CreateUserCommand(
                 command.username(),
@@ -60,6 +62,7 @@ public class AuthService {
                 command.chatTimeRanges()
         );
 
-        userService.createUser(createUserCommand);
+        UserDetailInfo userInfo = userService.createUser(createUserCommand);
+        return SignupInfo.from(userInfo);
     }
 }

--- a/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/service/AuthService.java
@@ -2,14 +2,18 @@ package org.pgsg.user_service.auth.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.pgsg.user_service.auth.application.dto.command.LoginUserCommand;
+import org.pgsg.user_service.auth.application.dto.command.SignupUserCommand;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
 import org.pgsg.user_service.auth.domain.JwtTokenProvider;
 import org.pgsg.user_service.auth.domain.TokenRepository;
 import org.pgsg.user_service.auth.domain.UserAuthenticator;
 import org.pgsg.user_service.auth.domain.model.TokenPair;
 import org.pgsg.user_service.user.application.UserService;
+import org.pgsg.user_service.user.application.dto.command.CreateUserCommand;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -22,6 +26,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenRepository tokenRepository;
     private final UserAuthenticator userAuthenticator;
+    private final PasswordEncoder passwordEncoder;
 
     //로그인 기능
     public AuthInfo login(LoginUserCommand command) {
@@ -41,5 +46,20 @@ public class AuthService {
     //로그아웃 기능
     public void logout(UUID userId) {
         tokenRepository.deleteRefreshToken(userId);
+    }
+
+    @Transactional
+    public void signup(SignupUserCommand command) {
+        String encryptedPassword = passwordEncoder.encode(command.password());
+        CreateUserCommand createUserCommand = new CreateUserCommand(
+                command.username(),
+                encryptedPassword,
+                command.userRole(),
+                command.name(),
+                command.nickname(),
+                command.chatTimeRanges()
+        );
+
+        userService.createUser(createUserCommand);
     }
 }

--- a/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
@@ -1,10 +1,12 @@
 package org.pgsg.user_service.auth.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
 import org.pgsg.user_service.auth.application.service.AuthService;
 import org.pgsg.user_service.auth.infrastructure.UserDetailsImpl;
 import org.pgsg.user_service.auth.presentation.dto.request.UserLoginRequest;
+import org.pgsg.user_service.auth.presentation.dto.request.UserSignupRequest;
 import org.pgsg.user_service.auth.presentation.dto.response.UserLoginResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,5 +34,10 @@ public class AuthController {
     public void logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 인증 객체에서 UUID를 꺼내 서비스에 로그아웃 요청
         authService.logout(userDetails.getUuid());
+    }
+
+    @PostMapping("/signup")
+    public void signup(@Valid @RequestBody UserSignupRequest userSignupRequest) {
+        authService.signup(userSignupRequest.toCommand());
     }
 }

--- a/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
@@ -3,11 +3,13 @@ package org.pgsg.user_service.auth.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
+import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
 import org.pgsg.user_service.auth.application.service.AuthService;
 import org.pgsg.user_service.auth.infrastructure.UserDetailsImpl;
 import org.pgsg.user_service.auth.presentation.dto.request.UserLoginRequest;
 import org.pgsg.user_service.auth.presentation.dto.request.UserSignupRequest;
 import org.pgsg.user_service.auth.presentation.dto.response.UserLoginResponse;
+import org.pgsg.user_service.auth.presentation.dto.response.UserSignupResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,7 +39,9 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public void signup(@Valid @RequestBody UserSignupRequest userSignupRequest) {
-        authService.signup(userSignupRequest.toCommand());
+    public UserSignupResponse signup(@Valid @RequestBody UserSignupRequest userSignupRequest) {
+        SignupInfo info = authService.signup(userSignupRequest.toCommand());
+
+        return UserSignupResponse.from(info);
     }
 }

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
@@ -46,7 +46,7 @@ public record UserSignupRequest(
             @NotNull(message = "종료 시간은 필수입니다.")
             LocalTime endTime
     ) {
-        public CreateChatTimeCommand toCreateCommand() {
+        public CreateChatTimeCommand toCommand() {
             return new CreateChatTimeCommand(dayOfWeek, startTime, endTime);
         }
     }
@@ -54,13 +54,13 @@ public record UserSignupRequest(
     // Request DTO를 서비스 계층에서 사용할 Command 객체로 변환
     public SignupUserCommand toCommand() {
         return new SignupUserCommand(
-                this.username,
-                this.password,
-                UserRole.find(this.userRole.toUpperCase()),
-                this.name,
-                this.nickname,
-                this.chatTimeRanges.stream()
-                        .map(ChatTimeRequest::toCreateCommand)
+                username,
+                password,
+                UserRole.find(userRole),
+                name,
+                nickname,
+                chatTimeRanges.stream()
+                        .map(ChatTimeRequest::toCommand)
                         .toList()
         );
     }

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
@@ -1,0 +1,67 @@
+package org.pgsg.user_service.auth.presentation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.pgsg.user_service.auth.application.dto.command.SignupUserCommand;
+import org.pgsg.user_service.user.application.dto.command.CreateChatTimeCommand;
+import org.pgsg.user_service.user.domain.model.UserRole;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+
+public record UserSignupRequest(
+        @NotBlank(message = "아이디는 필수 입력 값입니다.")
+        @Size(max = 12, message = "아이디는 최대 12자까지 가능합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        String password,
+
+        @NotBlank(message = "권한 정보는 필수 입력 값입니다.")
+        String userRole,
+
+        @NotBlank(message = "이름은 필수 입력 값입니다.")
+        String name,
+
+        @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        String nickname,
+
+		@Valid
+        @NotEmpty(message = "채팅 가능 시간은 최소 하나 이상 등록해야 합니다.")
+        List<ChatTimeRequest> chatTimeRanges
+) {
+    //채팅 가능 시간 정보만을 담당하는 내부 중첩 record
+    public record ChatTimeRequest(
+            @NotNull(message = "요일 정보는 필수입니다.")
+            DayOfWeek dayOfWeek,
+
+            @NotNull(message = "시작 시간은 필수입니다.")
+            LocalTime startTime,
+
+            @NotNull(message = "종료 시간은 필수입니다.")
+            LocalTime endTime
+    ) {
+        public CreateChatTimeCommand toCreateCommand() {
+            return new CreateChatTimeCommand(dayOfWeek, startTime, endTime);
+        }
+    }
+
+    // Request DTO를 서비스 계층에서 사용할 Command 객체로 변환
+    public SignupUserCommand toCommand() {
+        return new SignupUserCommand(
+                this.username,
+                this.password,
+                UserRole.find(this.userRole.toUpperCase()),
+                this.name,
+                this.nickname,
+                this.chatTimeRanges.stream()
+                        .map(ChatTimeRequest::toCreateCommand)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserSignupRequest.java
@@ -1,10 +1,7 @@
 package org.pgsg.user_service.auth.presentation.dto.request;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import org.pgsg.user_service.auth.application.dto.command.SignupUserCommand;
 import org.pgsg.user_service.user.application.dto.command.CreateChatTimeCommand;
 import org.pgsg.user_service.user.domain.model.UserRole;
@@ -12,30 +9,36 @@ import org.pgsg.user_service.user.domain.model.UserRole;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
-
+import java.util.Objects;
 
 public record UserSignupRequest(
+
         @NotBlank(message = "아이디는 필수 입력 값입니다.")
-        @Size(max = 12, message = "아이디는 최대 12자까지 가능합니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{8,12}$", message = "아이디는 최소 8글자, 최대 12글자의 영문 대/소문자, 숫자만 허용합니다.")
         String username,
 
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]{8,20}$", message = "비밀번호는 최소 8글자, 최대 20글자의 영문 대/소문자, 숫자, 특수문자만 허용합니다.")
         String password,
 
         @NotBlank(message = "권한 정보는 필수 입력 값입니다.")
+        @Pattern(regexp = "^(?i)(USER|MANAGER|MASTER|ROLE_USER|ROLE_MANAGER|ROLE_MASTER|일반 사용자|관리자|총관리자)$", message = "올바른 권한 형식이 아닙니다.")
         String userRole,
 
         @NotBlank(message = "이름은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z가-힣]{1,20}$", message = "이름은 최대 20자까지, 한글과 영문만 허용합니다.")
         String name,
 
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,20}$", message = "닉네임은 최대 20자까지, 한글, 영문, 숫자만 허용합니다.")
         String nickname,
 
-		@Valid
+        @Valid
+        @NotNull
         @NotEmpty(message = "채팅 가능 시간은 최소 하나 이상 등록해야 합니다.")
         List<ChatTimeRequest> chatTimeRanges
 ) {
-    //채팅 가능 시간 정보만을 담당하는 내부 중첩 record
+    // 채팅 가능 시간 정보만을 담당하는 내부 중첩 record
     public record ChatTimeRequest(
             @NotNull(message = "요일 정보는 필수입니다.")
             DayOfWeek dayOfWeek,
@@ -60,6 +63,7 @@ public record UserSignupRequest(
                 name,
                 nickname,
                 chatTimeRanges.stream()
+                        .filter(Objects::nonNull)
                         .map(ChatTimeRequest::toCommand)
                         .toList()
         );

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserSignupResponse.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserSignupResponse.java
@@ -1,0 +1,21 @@
+package org.pgsg.user_service.auth.presentation.dto.response;
+
+import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
+
+import java.util.UUID;
+
+public record UserSignupResponse(
+		UUID userId,
+		String username,
+		String nickname
+		// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+) {
+	public static UserSignupResponse from(SignupInfo signupInfo) {
+		return new UserSignupResponse(
+				signupInfo.userId(),
+				signupInfo.username(),
+				signupInfo.nickname()
+				// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+		);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/application/UserService.java
+++ b/src/main/java/org/pgsg/user_service/user/application/UserService.java
@@ -1,6 +1,7 @@
 package org.pgsg.user_service.user.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.pgsg.user_service.user.application.dto.command.CreateUserCommand;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
@@ -8,6 +9,7 @@ import org.pgsg.user_service.user.domain.model.User;
 import org.pgsg.user_service.user.domain.model.UserRole;
 import org.pgsg.user_service.user.domain.repository.UserRepository;
 import org.pgsg.user_service.user.domain.service.RoleCheck;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 
 // TODO: CQRS 패턴 도입
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -34,10 +37,13 @@ public class UserService {
 			throw new AccessDeniedException("관리자를 등록할 권한이 없습니다.");
 		}
 
-		User newUser = createdUserCommand.toUserEntity();
-		User savedUser = userRepository.save(newUser);
+		try {
+			User savedUser = userRepository.save(createdUserCommand.toUserEntity());
 
-		return UserDetailInfo.from(savedUser);
+			return UserDetailInfo.from(savedUser);
+		} catch (DataIntegrityViolationException e) {
+			throw new IllegalArgumentException("이미 등록된 회원입니다.");
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/pgsg/user_service/user/application/UserService.java
+++ b/src/main/java/org/pgsg/user_service/user/application/UserService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
-//TODO: CQRS 패턴 도입
+// TODO: CQRS 패턴 도입
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -25,6 +25,15 @@ public class UserService {
 
 	@Transactional
 	public UserDetailInfo createUser(CreateUserCommand createdUserCommand) {
+		// TODO: GlobalExceptionHandler 도입 시 회원 도메인 전용 커스텀 예외 클래스로 대체
+		if (userRepository.existsByUsername(createdUserCommand.username())) {
+			throw new IllegalArgumentException("이미 등록된 회원입니다.");
+		}
+		// TODO: GlobalExceptionHandler 도입 시 회원 도메인 전용 커스텀 예외 클래스로 대체
+		if (UserRole.isAdmin(createdUserCommand.userRole()) && !roleCheck.hasRole(UserRole.MASTER)) {
+			throw new AccessDeniedException("관리자를 등록할 권한이 없습니다.");
+		}
+
 		User newUser = createdUserCommand.toUserEntity();
 		User savedUser = userRepository.save(newUser);
 

--- a/src/main/java/org/pgsg/user_service/user/application/UserService.java
+++ b/src/main/java/org/pgsg/user_service/user/application/UserService.java
@@ -1,6 +1,7 @@
 package org.pgsg.user_service.user.application;
 
 import lombok.RequiredArgsConstructor;
+import org.pgsg.user_service.user.application.dto.command.CreateUserCommand;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
 import org.pgsg.user_service.user.domain.model.User;
@@ -23,7 +24,11 @@ public class UserService {
 	private final RoleCheck roleCheck;
 
 	@Transactional
-	public void createUser() {
+	public UserDetailInfo createUser(CreateUserCommand createdUserCommand) {
+		User newUser = createdUserCommand.toUserEntity();
+		User savedUser = userRepository.save(newUser);
+
+		return UserDetailInfo.from(savedUser);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateChatTimeCommand.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateChatTimeCommand.java
@@ -1,0 +1,16 @@
+package org.pgsg.user_service.user.application.dto.command;
+
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record CreateChatTimeCommand(
+		DayOfWeek dayOfWeek,
+		LocalTime startTime,
+		LocalTime endTime
+) {
+	public ChatTimeRange to() {
+		return ChatTimeRange.of(dayOfWeek, startTime, endTime);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateChatTimeCommand.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateChatTimeCommand.java
@@ -10,7 +10,7 @@ public record CreateChatTimeCommand(
 		LocalTime startTime,
 		LocalTime endTime
 ) {
-	public ChatTimeRange to() {
+	public ChatTimeRange toChatTime() {
 		return ChatTimeRange.of(dayOfWeek, startTime, endTime);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateUserCommand.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateUserCommand.java
@@ -1,0 +1,34 @@
+package org.pgsg.user_service.user.application.dto.command;
+
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
+import org.pgsg.user_service.user.domain.model.User;
+import org.pgsg.user_service.user.domain.model.UserRole;
+
+import java.util.List;
+import java.util.Objects;
+
+public record CreateUserCommand(
+		String username,
+		String password,
+		UserRole userRole,
+		String name,
+		String nickname,
+		List<CreateChatTimeCommand> chatTimeRangeInfos
+) {
+	public List<ChatTimeRange> getChatTimeRanges() {
+		if (chatTimeRangeInfos == null || chatTimeRangeInfos.isEmpty()) {
+			return List.of();
+		}
+		return chatTimeRangeInfos.stream()
+				.filter(Objects::nonNull)
+				.map(CreateChatTimeCommand::to)
+				.toList();
+	}
+
+	public User toUserEntity() {
+		User newUser = User.create(username, password, userRole, name, nickname);
+		newUser.addChatTimeRangeList(getChatTimeRanges());
+
+		return newUser;
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateUserCommand.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/command/CreateUserCommand.java
@@ -21,7 +21,7 @@ public record CreateUserCommand(
 		}
 		return chatTimeRangeInfos.stream()
 				.filter(Objects::nonNull)
-				.map(CreateChatTimeCommand::to)
+				.map(CreateChatTimeCommand::toChatTime)
 				.toList();
 	}
 

--- a/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
@@ -28,6 +28,16 @@ public class ChatTimeRange {
 	private LocalTime endTime;
 
 	public static ChatTimeRange of(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+		validateChatTime(dayOfWeek, startTime, endTime);
 		return new ChatTimeRange(dayOfWeek, startTime, endTime);
+	}
+
+	private static void validateChatTime(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+		if (dayOfWeek == null || startTime == null || endTime == null) {
+			throw new IllegalArgumentException("요일/시작 시간/종료 시간은 필수입니다.");
+		}
+		if (!startTime.isBefore(endTime)) {
+			throw new IllegalArgumentException("시작 시간은 종료 시간보다 빨라야 합니다.");
+		}
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/domain/model/User.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/User.java
@@ -15,10 +15,7 @@ import java.util.UUID;
 @Table(
 		name = "p_user",
 		uniqueConstraints = {
-				@UniqueConstraint(
-						name = "uk_user_username",
-						columnNames = {"username"}
-				)
+				@UniqueConstraint(name = "uk_user_username", columnNames = {"username"})
 		}
 )
 @Entity
@@ -40,15 +37,15 @@ public class User {
 	@Column(name = "user_role", nullable = false)
 	private UserRole userRole;
 
-	@Column(name = "name", nullable = false)
+	@Column(name = "name", length = 20, nullable = false)
 	private String name;
 
-	@Column(name = "nickname", nullable = false)
+	@Column(name = "nickname", length = 20, nullable = false)
 	private String nickname;
 
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "p_chat_time_range", joinColumns = @JoinColumn(name = "user_id"))
-	private List<ChatTimeRange> chatTimeRange = new ArrayList<>();
+	private final List<ChatTimeRange> chatTimeRanges = new ArrayList<>();
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private User(String username, String password, UserRole userRole, String name, String nickname) {
@@ -76,7 +73,7 @@ public class User {
 
 	// TODO: 채팅가능시간 관련 세부 로직 추가(인증 로직 구현 이후 회원 관련 기능 구현 시)
 	public void addChatTimeRangeList(List<ChatTimeRange> chatTimeRanges) {
-		this.chatTimeRange.addAll(chatTimeRanges);
+		this.chatTimeRanges.addAll(chatTimeRanges);
 	}
 
 	public void addChatTimeRange(ChatTimeRange chatTimeRange) {

--- a/src/main/java/org/pgsg/user_service/user/domain/model/User.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/User.java
@@ -75,4 +75,11 @@ public class User {
 	}
 
 	// TODO: 채팅가능시간 관련 세부 로직 추가(인증 로직 구현 이후 회원 관련 기능 구현 시)
+	public void addChatTimeRangeList(List<ChatTimeRange> chatTimeRanges) {
+		this.chatTimeRange.addAll(chatTimeRanges);
+	}
+
+	public void addChatTimeRange(ChatTimeRange chatTimeRange) {
+		addChatTimeRangeList(List.of(chatTimeRange));
+	}
 }

--- a/src/main/java/org/pgsg/user_service/user/domain/model/UserRole.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/UserRole.java
@@ -12,6 +12,10 @@ public enum UserRole {
 		return "ROLE_" + this.name();
 	}
 
+	public static boolean isAdmin(UserRole userRole) {
+		return userRole == MANAGER || userRole == MASTER;
+	}
+
 	public static UserRole find(String userRole) {
 		return Arrays.stream(UserRole.values())
 				.filter(role -> role.getRole().equals(userRole))

--- a/src/main/java/org/pgsg/user_service/user/domain/model/UserRole.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/UserRole.java
@@ -1,12 +1,19 @@
 package org.pgsg.user_service.user.domain.model;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 
+@Getter
+@RequiredArgsConstructor
 public enum UserRole {
 
-	USER,
-	MANAGER,
-	MASTER;
+	USER("일반 사용자"),
+	MANAGER("관리자"),
+	MASTER("총관리자");
+
+	private final String description;
 
 	public String getRole() {
 		return "ROLE_" + this.name();
@@ -16,10 +23,22 @@ public enum UserRole {
 		return userRole == MANAGER || userRole == MASTER;
 	}
 
-	public static UserRole find(String userRole) {
+	public static UserRole find(String userRoleInfo) {
+		if (userRoleInfo == null || userRoleInfo.isBlank()) {
+			throw new IllegalArgumentException("권한 정보가 비어있습니다.");
+		}
+
+		String trimmedInfo = userRoleInfo.trim();
+
 		return Arrays.stream(UserRole.values())
-				.filter(role -> role.getRole().equals(userRole))
+				.filter(role -> role.isMatched(trimmedInfo))
 				.findAny()
-				.orElseThrow(() -> new IllegalArgumentException("해당하는 회원권한을 찾을 수 없습니다."));	// 현재는 임시로 IllegalArgumentException 사용, 커스텀 예외 클래스 추가 시 교체 예정
+				.orElseThrow(() -> new IllegalArgumentException("해당하는 회원권한을 찾을 수 없습니다: " + userRoleInfo));
+	}
+
+	private boolean isMatched(String roleInfo) {
+		return this.name().equalsIgnoreCase(roleInfo)
+				|| this.getRole().equalsIgnoreCase(roleInfo)
+				|| this.description.equals(roleInfo);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/domain/repository/UserRepository.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/repository/UserRepository.java
@@ -9,8 +9,11 @@ import java.util.UUID;
 public interface UserRepository {
 
 	User save(User user);
+
 	Optional<User> findById(UUID userId);
 
 	// 로그인 진행 시 사용할 회원 조회 메서드
 	Optional<User> findByUsername(String username);
+
+	boolean existsByUsername(String username);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,11 @@ spring:
   application:
     name: user-service
 
+  # 최초 실행 시 권한이 MASTER인 계정을 회원 DB에 저장
+  sql:
+    init:
+      mode: always
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/userdb}
     username: ${DB_USERNAME:postgres}
@@ -9,6 +14,7 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   jpa:
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: validate        # 운영: validate / 개발 초기: create
     properties:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,4 @@
 -- 마스터 관리자 계정 6개 생성
--- 비밀번호: admin1234! (BCrypt 암호화됨)
 
 INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
 SELECT gen_random_uuid(), 'admin1', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터1', 'MASTER_1'

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,26 @@
+-- 마스터 관리자 계정 6개 생성
+-- 비밀번호: admin1234! (BCrypt 암호화됨)
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin1', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터1', 'MASTER_1'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin1');
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin2', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터2', 'MASTER_2'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin2');
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin3', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터3', 'MASTER_3'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin3');
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin4', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터4', 'MASTER_4'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin4');
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin5', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터5', 'MASTER_5'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin5');
+
+INSERT INTO p_user (user_id, username, password, user_role, name, nickname)
+SELECT gen_random_uuid(), 'admin6', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'MASTER', '마스터6', 'MASTER_6'
+WHERE NOT EXISTS (SELECT 1 FROM p_user WHERE username = 'admin6');


### PR DESCRIPTION
### 작업 배경
- 회원/인증 도메인의 MVP 구현 작업 중 회원가입 기능 구현 작업 진행

### 작업 내용

- 인증(요청) -> 회원 -> 인증(응답) 순으로 작업이 진행되기 때문에, 회원가입 기능에서의 인증, 회원 도메인의 역할을 다음과 같이 구분하여 작업을 진행
  - 인증 도메인
    - 회원가입 요청에 관한 엔드포인트 제공
    - 회원 등록 전 입력 데이터 형식 검증, 비밀번호 암호화 등의 사전 작업 수행
  - 회원 도메인
    - 신규 회원 엔티티 생성 및 등록에 관한 application의 서비스 로직 구현

- 회원 도메인에서 회원 등록 시 중복된 username 사용 불가, 요청자의 권한이 총관리자일 때만 관리자, 총관리자 권한으로 회원 등록 가능하도록 제한
  - 처음으로 총관리자를 등록할 때는 서버 구동 시 `src/main/resources/data.sql`의 insert문을 통해 총관리자를 DB에 저장
- 인증 도메인의 presentation 패키지에 회원가입 요청, 응답 DTO 추가

### 테스트 여부

- 현재는 회원가입 기능 구현에 집중했기 때문에, 공통 모듈의 코드를 적용한 후 테스트를 진행할 예정

### 기타
- 회원 도메인뿐만 아니라 인증 도메인에서의 회원가입 관련 로직도 모두 구현하고 다시 pr을 업로드했습니다.

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #14 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원가입 API(/api/v1/auth/signup) 추가 및 가입 응답에 userId/username/nickname 제공
  * 가입 시 비밀번호 암호화 적용
  * 사용자 채팅 가능 시간(요일/시작/종료) 설정 및 전송 지원

* **Bug Fixes**
  * 채팅 시간 입력 검증 강화(시작시간<종료시간, null 검사 등)
  * 사용자명 중복 검사 및 중복 등록 예외 처리
  * 관리자 계정 생성 권한 제한 강화(MASTER 권한 필요)

* **Chores**
  * 초기 관리자 계정 데이터 추가(여러 관리 계정)
  * 데이터베이스 초기화 및 JPA 초기화 순서 설정 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->