### PR TITLE
[Feat] 회원 자신의 회원정보 조회 기능 구현

### DIFF
--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserSignupResponse.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserSignupResponse.java
@@ -2,20 +2,23 @@ package org.pgsg.user_service.auth.presentation.dto.response;
 
 import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record UserSignupResponse(
 		UUID userId,
 		String username,
-		String nickname
-		// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+		String nickname,
+		LocalDateTime createdAt,
+		UUID createdBy
 ) {
 	public static UserSignupResponse from(SignupInfo signupInfo) {
 		return new UserSignupResponse(
 				signupInfo.userId(),
 				signupInfo.username(),
-				signupInfo.nickname()
-				// TODO: 공통모듈 도입 이후 createdAt, createdBy 필드 추가
+				signupInfo.nickname(),
+				signupInfo.createdAt(),
+				signupInfo.createdBy()
 		);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/presentation/UserController.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/UserController.java
@@ -1,9 +1,11 @@
 package org.pgsg.user_service.user.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.pgsg.config.security.UserDetailsImpl;
 import org.pgsg.user_service.user.application.UserService;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
 import org.pgsg.user_service.user.presentation.dto.response.UserDetailResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,13 @@ public class UserController {
 	@GetMapping("/{userId}")
 	public UserDetailResponse getUser(@PathVariable("userId") UUID userId) {
 		UserDetailInfo userDetailInfo = userService.getUserForAdmin(userId);
+
+		return UserDetailResponse.from(userDetailInfo);
+	}
+
+	@GetMapping("/me")
+	public UserDetailResponse getUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		UserDetailInfo userDetailInfo = userService.getUser(userDetails.getUuid());
 
 		return UserDetailResponse.from(userDetailInfo);
 	}


### PR DESCRIPTION
### 작업 배경
- 로그인 기능 테스트 결과 확인용 회원 조회 기능 추가

### 작업 내용
- 로그인한 회원 자신의 회원 정보 조회 기능 구현

### 테스트 여부
- postman 테스트 완료

- 로그인할 계정은 아래와 동일

    <details>
    
    <summary>실행 결과 캡처</summary>
    
    <img width="1721" height="1097" alt="image" src="https://github.com/user-attachments/assets/8b0d9d4a-381f-4322-8e13-1bc5d1c37a69" />
    
    </details>


- 로그인 성공 시

    <details>
    
    <summary>실행 결과 캡처</summary>
    
    <img width="1716" height="1481" alt="image" src="https://github.com/user-attachments/assets/edf29a19-0cb1-4790-af18-a1c30fdd3c17" />
    
    </details>


- 로그아웃 이후 해당 api 호출 시

    <details>
    
    <summary>실행 결과 캡처</summary>
    
    <img width="1699" height="1359" alt="image" src="https://github.com/user-attachments/assets/9e377c65-15bb-46ef-9bdf-5eb7e8ebcff7" />
    
    </details>

### 기타
- 

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #30 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원가입 응답에 생성 시간(`createdAt`)과 생성자(`createdBy`) 정보 필드 추가
  * 인증된 사용자가 자신의 정보를 조회할 수 있는 개인 프로필 조회 엔드포인트(`GET /api/v1/users/me`) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->