### PR TITLE
[Feat] 게이트웨이 전용 토큰 검증 api 구현

### DIFF
--- a/src/main/java/org/pgsg/user_service/auth/application/service/TokenService.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/service/TokenService.java
@@ -108,8 +108,7 @@ public class TokenService {
 			UUID userId = UUID.fromString(tokenProvider.getSubjectFromExpiredAccessToken(normalizedToken));
 			return tokenRepository.existsByBlacklist(userId, normalizedToken);
 		} catch (Exception e) {
-			// 검증할 accessToken에서의 userId 추출 작업 실패 등 모든 예외 상황은
-			// 블랙리스트에 없는 것으로 간주(어차피 이후 게이트웨이 파싱에서 걸러짐)
+			// try 블록 안에서 발생한 모든 예외 상황은 토큰이 블랙리스트에 포함된 것과 동일하게 간주
 			return true;
 		}
 	}

--- a/src/main/java/org/pgsg/user_service/auth/application/service/TokenService.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/service/TokenService.java
@@ -103,8 +103,14 @@ public class TokenService {
 	 */
 	public boolean isBlacklisted(String accessToken) {
 		// 토큰에서 사용자 ID를 추출하여 해당 키로 저장된 토큰이 있는지 확인
-		String normalizedToken = JwtUtils.normalizeToken(accessToken);
-		UUID userId = UUID.fromString(tokenProvider.getSubjectFromExpiredAccessToken(normalizedToken));
-		return tokenRepository.existsByBlacklist(userId, normalizedToken);
+		try {
+			String normalizedToken = JwtUtils.normalizeToken(accessToken);
+			UUID userId = UUID.fromString(tokenProvider.getSubjectFromExpiredAccessToken(normalizedToken));
+			return tokenRepository.existsByBlacklist(userId, normalizedToken);
+		} catch (Exception e) {
+			// 검증할 accessToken에서의 userId 추출 작업 실패 등 모든 예외 상황은
+			// 블랙리스트에 없는 것으로 간주(어차피 이후 게이트웨이 파싱에서 걸러짐)
+			return true;
+		}
 	}
 }

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/security/config/UserSecurityConfig.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/security/config/UserSecurityConfig.java
@@ -41,7 +41,7 @@ public class UserSecurityConfig implements SecurityConfig {
                         -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/auth/reissue").permitAll()
-                        .requestMatchers("/internal/v1/users/**").permitAll()
+                        .requestMatchers("/internal/v1/**").permitAll()
                         .requestMatchers("/favicon.ico", "/error").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/org/pgsg/user_service/auth/presentation/AuthInternalController.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/AuthInternalController.java
@@ -1,0 +1,27 @@
+package org.pgsg.user_service.auth.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.pgsg.user_service.auth.application.service.TokenService;
+import org.pgsg.user_service.auth.presentation.dto.request.UserVerifyRequest;
+import org.pgsg.user_service.auth.presentation.dto.response.UserVerifyResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/auth")
+@RequiredArgsConstructor
+public class AuthInternalController {
+
+	private final TokenService tokenService;
+
+	@PostMapping("/verify")
+	public UserVerifyResponse verifyToken(@Valid @RequestBody UserVerifyRequest userVerifyRequest) {
+		boolean blacklisted = tokenService.isBlacklisted(userVerifyRequest.accessToken());
+
+		// isVerifiedToken = !blacklisted
+		return new UserVerifyResponse(!blacklisted);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserVerifyRequest.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserVerifyRequest.java
@@ -1,0 +1,9 @@
+package org.pgsg.user_service.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserVerifyRequest(
+		@NotBlank
+		String accessToken
+) {
+}

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserVerifyResponse.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserVerifyResponse.java
@@ -1,0 +1,6 @@
+package org.pgsg.user_service.auth.presentation.dto.response;
+
+public record UserVerifyResponse(
+		boolean isVerifiedToken
+) {
+}


### PR DESCRIPTION
### 작업 배경
- 토큰의 관리는 user-service에서 수행하고, 토큰의 검증은 게이트웨이에서 수행하므로, 게이트웨이가 user-service에게 토큰 검증을 요청할 때 사용하기 위한 api가 필요
(게이트웨이의 인증 필터에서는 토큰 검증이 완료되어야 토큰 파싱을 진행하도록 하기 위해 FeignClient 기반 동기식 호출 방식 사용)

### 작업 내용
- 내부 호출용 `/internal/v1/auth/verify` api 구현 

### 테스트 여부
- postman 테스트 진행

    <details>
    
    <summary>사용자 로그인</summary>

    * 게이트웨이를 경유하는 요청이므로 postman 테스트 시에는 게이트웨이의 포트번호(8090) 사용

    <img width="1711" height="1341" alt="image" src="https://github.com/user-attachments/assets/6ab7778a-593f-4616-b4dc-790f1c9dd17a" />
    
    </details>

    <details>
    
    <summary>게이트웨이의 accessToken 검증 요청(로그인한 사용자의 accessToken)</summary>
    
    * 내부 호출용 api이므로 postman 테스트 시에는 user-service의 포트번호(18099) 사용
    
    <img width="1726" height="1369" alt="image" src="https://github.com/user-attachments/assets/36c52b88-14b9-462a-8aba-7e3da069c45b" />
    
    </details>

    <details>
    
    <summary>사용자 로그아웃 진행</summary>

    * 캡처에서는 header 추가하는 칸이 작아 accessToken의 일부가 잘렸지만 로그인할 때 발급된 accessToken을 사용했습니다.

    <img width="1718" height="1092" alt="image" src="https://github.com/user-attachments/assets/9aa95feb-ff8f-4c7f-9941-582b4c2e7f9c" />
    
    </details>

    <details>
    
    <summary>게이트웨이의 accessToken 검증 요청(로그아웃한 사용자의 accessToken)</summary>
    
    <img width="1705" height="1269" alt="image" src="https://github.com/user-attachments/assets/8398e1e0-1a77-4f67-bb64-6ca026968ec0" />
    
    </details>

    <details>
    
    <summary>postman 수행 기록</summary>
    
    <img width="2505" height="857" alt="image" src="https://github.com/user-attachments/assets/ec8fd343-3490-4946-96ec-38caff8ecef1" />
    
    <img width="2526" height="640" alt="image" src="https://github.com/user-attachments/assets/a6c86eff-83af-4a50-91af-0291bf1d7ab7" />
    
    
    </details>

### 기타
- 

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #32 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내부용 토큰 검증 API(POST /internal/v1/auth/verify)가 추가되었습니다.

* **개선사항**
  * 토큰 블랙리스트 확인 로직이 강화되어 예외 발생 시 안전하게 차단 처리됩니다.
  * 내부 엔드포인트에 대한 허용 범위가 "/internal/v1/**"로 확대되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->