### PR TITLE
[Feat] 인증 도메인 단위테스트 진행

### DIFF
--- a/src/main/java/org/pgsg/user_service/auth/application/dto/info/AuthInfo.java
+++ b/src/main/java/org/pgsg/user_service/auth/application/dto/info/AuthInfo.java
@@ -1,15 +1,11 @@
 package org.pgsg.user_service.auth.application.dto.info;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.pgsg.config.security.token.TokenPair;
 
-@Getter
-@AllArgsConstructor
-public class AuthInfo {
-    private String accessToken;
-    private String refreshToken;
-
+public record AuthInfo(
+    String accessToken,
+    String refreshToken
+) {
     public static AuthInfo from(TokenPair tokenPair) {
         return new AuthInfo(tokenPair.getAccessToken(), tokenPair.getRefreshToken());
     }

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -20,9 +20,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 // TODO: 내부 로직은 gateway-server의 filter 패키지에서 활용(spring cloud gateway 사용 시, webflux로 전환 필요)
-// TODO: gateway-server JWT 인증 필터 분리 완료 이후 deprecated 처리
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -91,16 +91,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		requestWrapper.addHeader(JwtUtils.HEADER_USER_NICKNAME, encodeValue(claims.get(JwtUtils.CLAIM_NICKNAME, String.class)));
 
 		// Enabled 여부는 boolean값을 string 타입으로 변환한 값을 저장
-		Boolean enabled = claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class);
-		requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled != null ? enabled.toString() : "false");
+		String enabled = Optional.ofNullable(claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class))
+				.map(Object::toString)
+				.orElse("false");
+		requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled);
 
 		return requestWrapper;
 	}
 
 	private String encodeValue(String value) {
-		if (value == null) {
-			return "";
-		}
-		return URLEncoder.encode(value, StandardCharsets.UTF_8);
+		return Optional.ofNullable(value)
+				.map(val -> URLEncoder.encode(val, StandardCharsets.UTF_8))
+				.orElse("");
 	}
 }

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -82,26 +82,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private HttpServletRequest createWrapperWithHeaders(HttpServletRequest request, Claims claims) {
 		HttpRequestHeaderWrapper requestWrapper = new HttpRequestHeaderWrapper(request);
 
-		requestWrapper.addHeader(JwtUtils.HEADER_USER_ID, claims.getSubject());
-		requestWrapper.addHeader(JwtUtils.HEADER_USERNAME, claims.get(JwtUtils.CLAIM_USERNAME, String.class));
-		requestWrapper.addHeader(JwtUtils.HEADER_ROLES, claims.get(JwtUtils.CLAIM_USER_ROLE, String.class));
+		Optional.ofNullable(claims.getSubject())
+				.ifPresent(id -> requestWrapper.addHeader(JwtUtils.HEADER_USER_ID, id));
+		Optional.ofNullable(claims.get(JwtUtils.CLAIM_USERNAME, String.class))
+				.ifPresent(username -> requestWrapper.addHeader(JwtUtils.HEADER_USERNAME, username));
+		Optional.ofNullable(claims.get(JwtUtils.CLAIM_USER_ROLE, String.class))
+				.ifPresent(roles -> requestWrapper.addHeader(JwtUtils.HEADER_ROLES, roles));
 
 		// 한글 헤더는 URL 인코딩 처리 (LoginFilter에서 디코딩함)
-		requestWrapper.addHeader(JwtUtils.HEADER_USER_NAME, encodeValue(claims.get(JwtUtils.CLAIM_NAME, String.class)));
-		requestWrapper.addHeader(JwtUtils.HEADER_USER_NICKNAME, encodeValue(claims.get(JwtUtils.CLAIM_NICKNAME, String.class)));
+		Optional.ofNullable(claims.get(JwtUtils.CLAIM_NAME, String.class))
+				.map(this::encodeValue)
+				.ifPresent(name -> requestWrapper.addHeader(JwtUtils.HEADER_USER_NAME, name));
+
+		Optional.ofNullable(claims.get(JwtUtils.CLAIM_NICKNAME, String.class))
+				.map(this::encodeValue)
+				.ifPresent(nickname -> requestWrapper.addHeader(JwtUtils.HEADER_USER_NICKNAME, nickname));
 
 		// Enabled 여부는 boolean값을 string 타입으로 변환한 값을 저장
-		String enabled = Optional.ofNullable(claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class))
+		Optional.ofNullable(claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class))
 				.map(Object::toString)
-				.orElse("false");
-		requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled);
+				.ifPresent(enabled -> requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled));
 
 		return requestWrapper;
 	}
 
 	private String encodeValue(String value) {
-		return Optional.ofNullable(value)
-				.map(val -> URLEncoder.encode(val, StandardCharsets.UTF_8))
-				.orElse("");
+		return URLEncoder.encode(value, StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapper.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapper.java
@@ -6,8 +6,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.util.*;
 import java.util.stream.Collectors;
 
-// TODO: 게이트웨이로 JWT 인증 필터 분리 완료 시 deprecated 처리
-// 게이트웨이의 JWT 인증 필터를 추가하기 전까지만 임시 사용할 Wrapper
+// 게이트웨이의 JWT 인증 필터를 추가하기 전까지 임시 사용할 Wrapper
 public class HttpRequestHeaderWrapper extends HttpServletRequestWrapper {
 
 	// Authorization 헤더 없이 서버가 인증을 마쳤다는 증표로 사용되는 내부 헤더 적용 -> 서버 권한 사칭 시도로 해석
@@ -47,7 +46,6 @@ public class HttpRequestHeaderWrapper extends HttpServletRequestWrapper {
 			return Collections.enumeration(Collections.singletonList(value));
 		}
 		if (lowerName.startsWith(FORBIDDEN_HEADER_PREFIX)) {
-			//
 			return Collections.emptyEnumeration();
 		}
 		// 원본 요청의 헤더명에 관한 목록 단위 값을 반환

--- a/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/AuthController.java
@@ -1,9 +1,7 @@
 package org.pgsg.user_service.auth.presentation;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.pgsg.config.security.UserDetailsImpl;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
 import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
 import org.pgsg.user_service.auth.application.service.AuthService;
@@ -13,8 +11,10 @@ import org.pgsg.user_service.auth.presentation.dto.request.UserSignupRequest;
 import org.pgsg.user_service.auth.presentation.dto.response.UserLoginResponse;
 import org.pgsg.user_service.auth.presentation.dto.response.UserSignupResponse;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -32,15 +32,19 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public Void logout(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request) {
-        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-        // 인증 객체에서 UUID를 꺼내 서비스에 로그아웃 요청
-        authService.logout(userDetails.getUuid(), accessToken);
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Void logout(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken
+    ) {
+        // 헤더에서 받은 UUID와 토큰을 서비스에 전달
+        authService.logout(userId, accessToken);
 
         return null;
     }
 
     @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
     public UserSignupResponse signup(@Valid @RequestBody UserSignupRequest userSignupRequest) {
         SignupInfo info = authService.signup(userSignupRequest.toCommand());
 

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserLoginRequest.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/request/UserLoginRequest.java
@@ -1,21 +1,14 @@
 package org.pgsg.user_service.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.pgsg.user_service.auth.application.dto.command.LoginUserCommand;
 
-@Getter
-@NoArgsConstructor
-public class UserLoginRequest {
-    @NotBlank
-    private String username;
-
-    @NotBlank
-    private String password;
-
+public record UserLoginRequest(
+        @NotBlank
+        String username,
+        @NotBlank
+        String password
+) {
     public LoginUserCommand toCommand() {
         return new LoginUserCommand(username, password);
     }

--- a/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserLoginResponse.java
+++ b/src/main/java/org/pgsg/user_service/auth/presentation/dto/response/UserLoginResponse.java
@@ -1,16 +1,12 @@
 package org.pgsg.user_service.auth.presentation.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
 
-@Getter
-@AllArgsConstructor
-public class UserLoginResponse {
-    private String accessToken;
-    private String refreshToken;
-
+public record UserLoginResponse(
+    String accessToken,
+    String refreshToken
+) {
     public static UserLoginResponse from(AuthInfo info) {
-        return new UserLoginResponse(info.getAccessToken(), info.getRefreshToken());
+        return new UserLoginResponse(info.accessToken(), info.refreshToken());
     }
 }

--- a/src/test/java/org/pgsg/user_service/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/application/service/AuthServiceTest.java
@@ -1,0 +1,136 @@
+package org.pgsg.user_service.auth.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.config.security.UserDetailsImpl;
+import org.pgsg.user_service.auth.application.dto.command.LoginUserCommand;
+import org.pgsg.user_service.auth.application.dto.command.ReissueUserCommand;
+import org.pgsg.user_service.auth.application.dto.command.SignupUserCommand;
+import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
+import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
+import org.pgsg.user_service.auth.domain.UserAuthenticator;
+import org.pgsg.user_service.user.application.UserCommandFacade;
+import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
+import org.pgsg.user_service.user.domain.model.UserRole;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserCommandFacade userCommandFacade;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private UserAuthenticator userAuthenticator;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private final UUID userId = UUID.randomUUID();
+    private final String username = "testuser";
+    private final String password = "password123";
+    private final String accessToken = "access.token";
+
+	@Test
+    @DisplayName("login - 성공: 사용자 인증 후 토큰을 발급한다")
+    void login_Success() {
+        // given
+        LoginUserCommand command = new LoginUserCommand(username, password);
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        AuthInfo expectedAuthInfo = mock(AuthInfo.class);
+
+        when(userAuthenticator.verify(username, password)).thenReturn(userDetails);
+        when(tokenService.issueTokenPair(userDetails)).thenReturn(expectedAuthInfo);
+
+        // when
+        AuthInfo result = authService.login(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedAuthInfo);
+        verify(userAuthenticator).verify(username, password);
+        verify(tokenService).issueTokenPair(userDetails);
+    }
+
+    @Test
+    @DisplayName("logout - 성공: 리프레시 토큰을 삭제하고 액세스 토큰을 블랙리스트에 추가한다")
+    void logout_Success() {
+        // when
+        authService.logout(userId, accessToken);
+
+        // then
+        verify(tokenService).deleteRefreshToken(userId);
+        verify(tokenService).addToBlacklist(userId, accessToken);
+    }
+
+    @Test
+    @DisplayName("signup - 성공: 비밀번호를 암호화하고 사용자를 생성한다")
+    void signup_Success() {
+        // given
+        SignupUserCommand command = new SignupUserCommand(
+                username, password, UserRole.USER, "Name", "Nickname", Collections.emptyList()
+        );
+        String encryptedPassword = "encryptedPassword";
+        
+        UserDetailInfo userDetailInfo = mock(UserDetailInfo.class);
+        when(userDetailInfo.userId()).thenReturn(userId);
+        when(userDetailInfo.username()).thenReturn(username);
+        when(userDetailInfo.nickname()).thenReturn("Nickname");
+        when(userDetailInfo.createdAt()).thenReturn(LocalDateTime.now());
+        when(userDetailInfo.createdBy()).thenReturn(userId);
+
+        when(passwordEncoder.encode(password)).thenReturn(encryptedPassword);
+        when(userCommandFacade.createUser(any())).thenReturn(userDetailInfo);
+
+        // when
+        SignupInfo result = authService.signup(command);
+
+        // then
+        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.username()).isEqualTo(username);
+        verify(passwordEncoder).encode(password);
+        verify(userCommandFacade).createUser(argThat(createUserCommand -> 
+            createUserCommand.password().equals(encryptedPassword) &&
+            createUserCommand.username().equals(username)
+        ));
+    }
+
+    @Test
+    @DisplayName("reissue - 성공: 토큰 검증 후 새로운 토큰을 발급한다")
+    void reissue_Success() {
+        // given
+		String refreshToken = "refresh.token";
+		ReissueUserCommand command = new ReissueUserCommand(accessToken, refreshToken);
+
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        AuthInfo expectedAuthInfo = mock(AuthInfo.class);
+
+        when(userAuthenticator.verifyToken(accessToken, refreshToken)).thenReturn(userDetails);
+        when(tokenService.issueTokenPair(userDetails)).thenReturn(expectedAuthInfo);
+
+        // when
+        AuthInfo result = authService.reissue(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedAuthInfo);
+        verify(userAuthenticator).verifyToken(accessToken, refreshToken);
+        verify(tokenService).issueTokenPair(userDetails);
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/application/service/TokenBlacklistTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/application/service/TokenBlacklistTest.java
@@ -92,7 +92,7 @@ class TokenBlacklistTest {
         given(tokenProvider.getSubjectFromExpiredAccessToken(anyString())).willThrow(new RuntimeException("Parsing Error"));
 
         // when
-        boolean result = tokenService.isBlacklisted(accessToken);
+        boolean result = tokenService.isBlacklisted("Bearer " + accessToken);
 
         // then
         assertThat(result).isTrue();

--- a/src/test/java/org/pgsg/user_service/auth/application/service/TokenBlacklistTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/application/service/TokenBlacklistTest.java
@@ -1,0 +1,100 @@
+package org.pgsg.user_service.auth.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.config.security.token.TokenProvider;
+import org.pgsg.user_service.auth.domain.TokenRepository;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Token Blacklist 관련 테스트")
+class TokenBlacklistTest {
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    private final UUID userId = UUID.randomUUID();
+    private final String accessToken = "mock.access.token";
+
+    @Test
+    @DisplayName("addToBlacklist - 성공: 토큰의 남은 유효시간만큼 블랙리스트에 저장한다")
+    void addToBlacklist_Success() {
+        // given
+        long remainingTime = 10000L;
+        given(tokenProvider.getRemainingTime(anyString())).willReturn(remainingTime);
+
+        // when
+        tokenService.addToBlacklist(userId, "Bearer " + accessToken);
+
+        // then
+        then(tokenRepository).should().saveBlacklist(eq(userId), eq(accessToken), eq(Duration.ofMillis(remainingTime)));
+    }
+
+    @Test
+    @DisplayName("addToBlacklist - 실패: 토큰 파싱 실패 시 에러 로그를 남기고 정상 종료된다 (예외 전파 안됨)")
+    void addToBlacklist_ParsingFail() {
+        // when
+        tokenService.addToBlacklist(userId, null);
+
+        // then
+        then(tokenRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted - 성공: 블랙리스트에 존재하면 true를 반환한다")
+    void isBlacklisted_True() {
+        // given
+        given(tokenProvider.getSubjectFromExpiredAccessToken(anyString())).willReturn(userId.toString());
+        given(tokenRepository.existsByBlacklist(userId, accessToken)).willReturn(true);
+
+        // when
+        boolean result = tokenService.isBlacklisted("Bearer " + accessToken);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted - 성공: 블랙리스트에 없으면 false를 반환한다")
+    void isBlacklisted_False() {
+        // given
+        given(tokenProvider.getSubjectFromExpiredAccessToken(anyString())).willReturn(userId.toString());
+        given(tokenRepository.existsByBlacklist(userId, accessToken)).willReturn(false);
+
+        // when
+        boolean result = tokenService.isBlacklisted("Bearer " + accessToken);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlacklisted - 예외 발생: 블랙리스트인 것으로 간주(true 반환)한다")
+    void isBlacklisted_Exception_ReturnsTrue() {
+        // given
+        given(tokenProvider.getSubjectFromExpiredAccessToken(anyString())).willThrow(new RuntimeException("Parsing Error"));
+
+        // when
+        boolean result = tokenService.isBlacklisted(accessToken);
+
+        // then
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/application/service/TokenServiceTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/application/service/TokenServiceTest.java
@@ -65,7 +65,7 @@ class TokenServiceTest {
         // then
         assertThat(result.accessToken()).isEqualTo(accessToken);
         assertThat(result.refreshToken()).isEqualTo(refreshToken);
-        then(tokenRepository).should().saveRefreshToken(eq(userId), eq(refreshToken), any(Duration.class));
+        then(tokenRepository).should().saveRefreshToken(eq(userId), eq(refreshToken), eq(Duration.ofMillis(3600000L)));
     }
 
     @Test

--- a/src/test/java/org/pgsg/user_service/auth/application/service/TokenServiceTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/application/service/TokenServiceTest.java
@@ -1,0 +1,135 @@
+package org.pgsg.user_service.auth.application.service;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.config.security.UserDetailsImpl;
+import org.pgsg.config.security.jwt.JwtProperties;
+import org.pgsg.config.security.token.TokenPair;
+import org.pgsg.config.security.token.TokenProvider;
+import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
+import org.pgsg.user_service.auth.domain.TokenRepository;
+import org.pgsg.user_service.user.domain.exception.UserServiceException;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    private final UUID userId = UUID.randomUUID();
+    private final String accessToken = "mock.access.token";
+    private final String refreshToken = "mock.refresh.token";
+
+    @Test
+    @DisplayName("issueTokenPair - 성공: 토큰 쌍을 생성하고 리프레시 토큰을 저장한다")
+    void issueTokenPair_Success() {
+        // given
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        given(userDetails.getUuid()).willReturn(userId);
+        
+        TokenPair tokenPair = mock(TokenPair.class);
+        given(tokenPair.getAccessToken()).willReturn(accessToken);
+        given(tokenPair.getRefreshToken()).willReturn(refreshToken);
+        
+        given(tokenProvider.createTokenPair(userDetails)).willReturn(tokenPair);
+        given(jwtProperties.getRefreshTokenExpiration()).willReturn(3600000L);
+
+        // when
+        AuthInfo result = tokenService.issueTokenPair(userDetails);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(accessToken);
+        assertThat(result.refreshToken()).isEqualTo(refreshToken);
+        then(tokenRepository).should().saveRefreshToken(eq(userId), eq(refreshToken), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("verifyTokenPair - 성공: 유효한 토큰 쌍인 경우 사용자 ID를 반환한다")
+    void verifyTokenPair_Success() {
+        // given
+        given(tokenProvider.getSubjectFromExpiredAccessToken(accessToken)).willReturn(userId.toString());
+        given(tokenProvider.validateToken(refreshToken)).willReturn(true);
+        
+        Claims claims = mock(Claims.class);
+        given(claims.get(anyString(), eq(String.class))).willReturn("refresh");
+        given(tokenProvider.parseClaims(refreshToken)).willReturn(claims);
+        given(tokenProvider.getUserId(refreshToken)).willReturn(userId);
+        
+        given(tokenRepository.findRefreshToken(userId)).willReturn(Optional.of(refreshToken));
+
+        // when
+        UUID result = tokenService.verifyTokenPair(accessToken, refreshToken);
+
+        // then
+        assertThat(result).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("verifyTokenPair - 실패: 토큰 정보가 일치하지 않거나 유효하지 않으면 예외가 발생한다")
+    void verifyTokenPair_Fail() {
+        // given
+        given(tokenProvider.getSubjectFromExpiredAccessToken(accessToken)).willReturn(userId.toString());
+        given(tokenProvider.validateToken(refreshToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.verifyTokenPair(accessToken, refreshToken))
+                .isInstanceOf(UserServiceException.class);
+    }
+
+    @Test
+    @DisplayName("validateRefreshToken - 성공: 저장된 리프레시 토큰과 일치하면 통과한다")
+    void validateRefreshToken_Success() {
+        // given
+        given(tokenRepository.findRefreshToken(userId)).willReturn(Optional.of(refreshToken));
+
+        // when & then
+        tokenService.validateRefreshToken(userId, refreshToken);
+        then(tokenRepository).should().findRefreshToken(userId);
+    }
+
+    @Test
+    @DisplayName("validateRefreshToken - 실패: 저장된 리프레시 토큰이 없거나 일치하지 않으면 예외가 발생한다")
+    void validateRefreshToken_Fail() {
+        // given
+        given(tokenRepository.findRefreshToken(userId)).willReturn(Optional.of("other.refresh.token"));
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.validateRefreshToken(userId, refreshToken))
+                .isInstanceOf(UserServiceException.class);
+    }
+
+    @Test
+    @DisplayName("deleteRefreshToken - 성공: 리프레시 토큰을 삭제한다")
+    void deleteRefreshToken_Success() {
+        // when
+        tokenService.deleteRefreshToken(userId);
+
+        // then
+        then(tokenRepository).should().deleteRefreshToken(userId);
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/security/UserAuthenticatorImplTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/security/UserAuthenticatorImplTest.java
@@ -1,0 +1,116 @@
+package org.pgsg.user_service.auth.infrastructure.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.config.security.UserDetailsImpl;
+import org.pgsg.user_service.auth.application.service.TokenService;
+import org.pgsg.user_service.user.application.UserQueryFacade;
+import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
+import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.pgsg.user_service.user.domain.model.UserRole;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserAuthenticatorImplTest {
+
+    @InjectMocks
+    private UserAuthenticatorImpl userAuthenticator;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private UserQueryFacade userQueryFacade;
+
+    private final UUID userId = UUID.randomUUID();
+    private final String username = "testuser";
+    private final String password = "password";
+    private final String accessToken = "access.token";
+    private final String refreshToken = "refresh.token";
+
+    @Test
+    @DisplayName("verify(username, password) - 성공: 인증 매니저를 통해 인증을 수행하고 UserDetails를 반환한다")
+    void verify_Success() {
+        // given
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        Authentication authentication = mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(userDetails);
+        given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .willReturn(authentication);
+
+        // when
+        UserDetailsImpl result = userAuthenticator.verify(username, password);
+
+        // then
+        assertThat(result).isEqualTo(userDetails);
+        then(authenticationManager).should().authenticate(argThat(token -> 
+            token.getPrincipal().equals(username) && token.getCredentials().equals(password)
+        ));
+    }
+
+    @Test
+    @DisplayName("verifyToken - 성공: 블랙리스트 확인 및 토큰 검증 후 최신 사용자 정보를 반환한다")
+    void verifyToken_Success() {
+        // given
+        given(tokenService.isBlacklisted(accessToken)).willReturn(false);
+        given(tokenService.verifyTokenPair(accessToken, refreshToken)).willReturn(userId);
+        
+        LoginUserDetailInfo loginInfo = new LoginUserDetailInfo(
+                userId, username, "hashedPassword", UserRole.USER, "Name", "Nick", true
+        );
+        given(userQueryFacade.getUserForAuth(userId)).willReturn(loginInfo);
+
+        // when
+        UserDetailsImpl result = userAuthenticator.verifyToken(accessToken, refreshToken);
+
+        // then
+        assertThat(result.getUuid()).isEqualTo(userId);
+        assertThat(result.getUsername()).isEqualTo(username);
+        then(tokenService).should().isBlacklisted(accessToken);
+        then(tokenService).should().verifyTokenPair(accessToken, refreshToken);
+        then(userQueryFacade).should().getUserForAuth(userId);
+    }
+
+    @Test
+    @DisplayName("verifyToken - 실패: 블랙리스트 토큰인 경우 예외를 발생시킨다")
+    void verifyToken_Blacklisted() {
+        // given
+        given(tokenService.isBlacklisted(accessToken)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userAuthenticator.verifyToken(accessToken, refreshToken))
+                .isInstanceOf(UserServiceException.class);
+        
+        then(tokenService).should().isBlacklisted(accessToken);
+        then(tokenService).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("checkBlacklist - 실패: 블랙리스트 토큰인 경우 예외를 발생시킨다")
+    void checkBlacklist_ThrowsException() {
+        // given
+        given(tokenService.isBlacklisted(accessToken)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userAuthenticator.checkBlacklist(accessToken))
+                .isInstanceOf(UserServiceException.class);
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -184,4 +184,44 @@ class JwtAuthenticationFilterTest {
         // 2. 토큰이 없으므로 검증 로직을 호출하지 않아야 함
         verify(tokenProvider, never()).validateToken(anyString());
     }
+
+    @Test
+    @DisplayName("성공: 일부 Claim이 null인 경우 해당 헤더는 생성되지 않는다")
+    void doFilterInternal_NullClaims_OmitHeaders() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenProvider.validateToken(accessToken)).thenReturn(true);
+        doNothing().when(userAuthenticator).checkBlacklist(accessToken);
+
+        // Name, Nickname, Enabled를 null로 설정
+        Claims claims = Jwts.claims()
+                .subject(userId.toString())
+                .add(JwtUtils.CLAIM_TOKEN_TYPE, "access")
+                .add(JwtUtils.CLAIM_USERNAME, "testuser")
+                .add(JwtUtils.CLAIM_USER_ROLE, "ROLE_USER")
+                .add(JwtUtils.CLAIM_NAME, null)
+                .add(JwtUtils.CLAIM_NICKNAME, null)
+                .add(JwtUtils.CLAIM_ENABLED, null)
+                .build();
+
+        when(tokenProvider.parseClaims(accessToken)).thenReturn(claims);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isEqualTo(userId.toString());
+        
+        // null인 Claim들에 대해서는 헤더가 존재하지 않아야 함 (null 반환)
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_NAME)).isNull();
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_NICKNAME)).isNull();
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_ENABLED)).isNull();
+    }
 }

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,187 @@
+package org.pgsg.user_service.auth.infrastructure.security.filter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.config.security.jwt.JwtUtils;
+import org.pgsg.config.security.token.TokenProvider;
+import org.pgsg.user_service.auth.domain.UserAuthenticator;
+import org.pgsg.user_service.user.domain.exception.UserErrorCode;
+import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private UserAuthenticator userAuthenticator;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private final String accessToken = "valid.access.token";
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        jwtAuthenticationFilter = new JwtAuthenticationFilter(tokenProvider, userAuthenticator);
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 토큰인 경우 Claims를 추출하여 헤더에 담는다")
+    void doFilterInternal_Success() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenProvider.validateToken(accessToken)).thenReturn(true);
+        doNothing().when(userAuthenticator).checkBlacklist(accessToken);
+
+        Claims claims = Jwts.claims()
+                .subject(userId.toString())
+                .add(JwtUtils.CLAIM_TOKEN_TYPE, "access")
+                .add(JwtUtils.CLAIM_USERNAME, "testuser")
+                .add(JwtUtils.CLAIM_USER_ROLE, "ROLE_USER")
+                .add(JwtUtils.CLAIM_NAME, "홍길동")
+                .add(JwtUtils.CLAIM_NICKNAME, "길동이")
+                .add(JwtUtils.CLAIM_ENABLED, true)
+                .build();
+
+        when(tokenProvider.parseClaims(accessToken)).thenReturn(claims);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isEqualTo(userId.toString());
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USERNAME)).isEqualTo("testuser");
+        // 한글 이름은 인코딩되어 있어야 함
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_NAME)).isNotEqualTo("홍길동");
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_ENABLED)).isEqualTo("true");
+    }
+
+    @Test
+    @DisplayName("실패: 블랙리스트 토큰인 경우 헤더 없이 다음 필터로 진행한다")
+    void doFilterInternal_Blacklisted() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenProvider.validateToken(accessToken)).thenReturn(true);
+        doThrow(new UserServiceException(UserErrorCode.UNAUTHORIZED))
+                .when(userAuthenticator).checkBlacklist(accessToken);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("실패: 토큰 타입이 ACCESS가 아닌(REFRESH 등) 경우, 토큰 내 정보가 있더라도 헤더에 담지 않고 사칭 헤더도 차단한다")
+    void doFilterInternal_InvalidTokenType() throws Exception {
+        // given: 유효한 서명이지만 타입이 REFRESH인 토큰 + 사칭 시도 헤더
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        request.addHeader(JwtUtils.HEADER_USER_ID, "malicious-user-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenProvider.validateToken(accessToken)).thenReturn(true);
+
+        // 토큰 내부에 사용자 ID가 들어있지만 타입이 'refresh'인 상황 시뮬레이션
+        Claims claims = Jwts.claims()
+                .subject(userId.toString())
+                .add(JwtUtils.CLAIM_TOKEN_TYPE, "refresh")
+                .build();
+        when(tokenProvider.parseClaims(accessToken)).thenReturn(claims);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then: 다음 필터로 전달된 요청 확인
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        // 1. 토큰 내에 userId가 있었음에도 'access' 타입이 아니므로 헤더에 등록되지 않아야 함
+        // 2. 원본 요청에 있던 사칭 헤더(malicious-user-id)도 차단되어야 함
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("실패: 토큰이 유효하지 않은(잘못된 서명 등) 경우, 사칭 헤더를 차단하고 다음 필터로 진행한다")
+    void doFilterInternal_InvalidToken() throws Exception {
+        // given: 유효하지 않은 토큰 + 사칭 헤더
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer invalid-token");
+        request.addHeader(JwtUtils.HEADER_USER_ID, "malicious-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // validateToken이 false를 반환하는 상황
+        when(tokenProvider.validateToken("invalid-token")).thenReturn(false);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then: 다음 필터로 위임될 때 사칭 방지용 Wrapper로 감싸졌는지 확인
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        // 유효하지 않은 토큰이므로 인증 정보가 없어야 하고, 사칭 헤더도 null이어야 함
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("실패: 토큰이 없는 경우에도 사칭 방지용 래퍼를 씌워 다음 필터로 진행한다")
+    void doFilterInternal_NoToken() throws Exception {
+        // given: Authorization 헤더가 없고 사칭 시도용 헤더만 있는 요청
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(JwtUtils.HEADER_USER_ID, "malicious-user-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when: 필터 수행
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then: 다음 필터로 위임될 때 사칭 방지용 Wrapper로 감싸졌는지 확인
+        ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(requestCaptor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = requestCaptor.getValue();
+        // 1. 사칭 헤더(X-User-Id)가 null로 차단되어야 함
+        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_ID)).isNull();
+        // 2. 토큰이 없으므로 검증 로직을 호출하지 않아야 함
+        verify(tokenProvider, never()).validateToken(anyString());
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapperTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapperTest.java
@@ -1,0 +1,71 @@
+package org.pgsg.user_service.auth.infrastructure.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pgsg.config.security.jwt.JwtUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpRequestHeaderWrapperTest {
+
+	private HttpRequestHeaderWrapper wrapper;
+
+    @BeforeEach
+    void setUp() {
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+
+        // 1. 정상적인 인증 요청 상황 시뮬레이션
+        mockRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-access-token");
+        
+        // 2. 사칭 공격 시도 시뮬레이션 (클라이언트가 직접 보낸 X-User-* 헤더)
+        mockRequest.addHeader(JwtUtils.HEADER_USER_ID, "malicious-user-id");
+
+        wrapper = new HttpRequestHeaderWrapper(mockRequest);
+    }
+
+    @Test
+    @DisplayName("getHeader - 원본 요청의 사칭 헤더(x-user-)는 무시하고 일반 헤더만 반환한다")
+    void getHeader_ForbiddenHeader() {
+        // when
+        String forbiddenHeader = wrapper.getHeader(JwtUtils.HEADER_USER_ID);
+        String normalHeader = wrapper.getHeader(HttpHeaders.AUTHORIZATION);
+
+        // then
+        assertThat(forbiddenHeader).isNull();
+        assertThat(normalHeader).isEqualTo("Bearer valid-access-token");
+    }
+
+    @Test
+    @DisplayName("인증 후: JwtFilter가 추가한 헤더는 정상적으로 조회되며, 원본 사칭 값은 덮어씌워진다")
+    void addHeader_AuthenticatedUser() {
+        // given
+        String authenticatedUserId = "real-user-123";
+
+        // when: JwtFilter가 토큰 검증 완료 후 사용자 정보를 Wrapper에 주입
+        wrapper.addHeader(JwtUtils.HEADER_USER_ID, authenticatedUserId);
+
+        // then: 추가된 인증 정보와 기존 인증 헤더가 공존함
+        assertThat(wrapper.getHeader(JwtUtils.HEADER_USER_ID)).isEqualTo(authenticatedUserId);
+        assertThat(wrapper.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer valid-access-token");
+    }
+
+    @Test
+    @DisplayName("getHeaderNames - 인증 헤더와 추가된 헤더만 포함하고, 사칭 시도된 원본 헤더는 제외한다")
+    void getHeaderNames_FiltersForbiddenAndIncludesAdded() {
+        // given
+        wrapper.addHeader(JwtUtils.HEADER_USER_ID, "real-user-123");
+
+        // when
+        List<String> names = Collections.list(wrapper.getHeaderNames());
+
+        // then
+        assertThat(names).contains(HttpHeaders.AUTHORIZATION.toLowerCase(), JwtUtils.HEADER_USER_ID.toLowerCase());
+        // getHeaderNames 결과에는 소문자로 변환된 헤더명들이 포함됨
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapperTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/web/HttpRequestHeaderWrapperTest.java
@@ -22,11 +22,37 @@ class HttpRequestHeaderWrapperTest {
 
         // 1. 정상적인 인증 요청 상황 시뮬레이션
         mockRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-access-token");
+        mockRequest.addHeader("X-Normal-Header", "normal-value");
         
-        // 2. 사칭 공격 시도 시뮬레이션 (클라이언트가 직접 보낸 X-User-* 헤더)
+        // 2. 사칭 공격 시도 시뮬레이션 (클라이언트가 직접 보낸 X-User-* 헤더들)
         mockRequest.addHeader(JwtUtils.HEADER_USER_ID, "malicious-user-id");
+        mockRequest.addHeader(JwtUtils.HEADER_USERNAME, "malicious-username");
 
         wrapper = new HttpRequestHeaderWrapper(mockRequest);
+    }
+
+    @Test
+    @DisplayName("getHeaderNames - 인증 헤더와 추가된 헤더만 포함하고, 사칭 시도된 원본 헤더는 모두 제외한다")
+    void getHeaderNames_Scenarios() {
+        // given: 필터에서 일부 정보만 추가한 상황
+        String realUserId = "real-user-123";
+        wrapper.addHeader(JwtUtils.HEADER_USER_ID, realUserId);
+
+        // when
+        List<String> names = Collections.list(wrapper.getHeaderNames());
+
+        // then
+        // 1. 원본 일반 헤더들은 포함되어야 함
+        assertThat(names).contains(HttpHeaders.AUTHORIZATION.toLowerCase(), "x-normal-header");
+        
+        // 2. 인증 후 추가된 헤더는 포함되어야 함
+        assertThat(names).contains(JwtUtils.HEADER_USER_ID.toLowerCase());
+
+        // 3. 원본에 있었으나 추가되지 않은 사칭 헤더(X-User-Username)는 제외되어야 함
+        assertThat(names).doesNotContain(JwtUtils.HEADER_USERNAME.toLowerCase());
+
+        // 4. 모든 헤더명은 소문자로 정규화되어 있어야 함 (Wrapper 구현 사양)
+        assertThat(names).allMatch(name -> name.equals(name.toLowerCase()));
     }
 
     @Test
@@ -56,16 +82,27 @@ class HttpRequestHeaderWrapperTest {
     }
 
     @Test
-    @DisplayName("getHeaderNames - 인증 헤더와 추가된 헤더만 포함하고, 사칭 시도된 원본 헤더는 제외한다")
-    void getHeaderNames_FiltersForbiddenAndIncludesAdded() {
+    @DisplayName("getHeaders - 추가된 헤더, 일반 원본 헤더, 금지된 원본 헤더에 대해 올바른 목록을 반환한다")
+    void getHeaders_Scenarios() {
         // given
-        wrapper.addHeader(JwtUtils.HEADER_USER_ID, "real-user-123");
+        String realUserId = "real-user-123";
+        wrapper.addHeader(JwtUtils.HEADER_USER_ID, realUserId);
 
-        // when
-        List<String> names = Collections.list(wrapper.getHeaderNames());
+        // when & then 1: 추가된 헤더 조회 (대소문자 구분 없음)
+        List<String> addedHeaders = Collections.list(wrapper.getHeaders(JwtUtils.HEADER_USER_ID));
+        assertThat(addedHeaders).containsExactly(realUserId);
+        
+        List<String> addedHeadersLower = Collections.list(wrapper.getHeaders(JwtUtils.HEADER_USER_ID.toLowerCase()));
+        assertThat(addedHeadersLower).containsExactly(realUserId);
 
-        // then
-        assertThat(names).contains(HttpHeaders.AUTHORIZATION.toLowerCase(), JwtUtils.HEADER_USER_ID.toLowerCase());
-        // getHeaderNames 결과에는 소문자로 변환된 헤더명들이 포함됨
+        // when & then 2: 일반 원본 헤더 조회
+        List<String> normalHeaders = Collections.list(wrapper.getHeaders(HttpHeaders.AUTHORIZATION));
+        assertThat(normalHeaders).containsExactly("Bearer valid-access-token");
+
+        // when & then 3: 금지된 원본 헤더(사칭 시도) 조회 -> 빈 목록이어야 함
+        // 참고: 이미 위에서 JwtUtils.HEADER_USER_ID를 addHeader 했으므로, 
+        // 사칭 시도 헤더를 테스트하기 위해 다른 금지된 헤더명을 사용
+        List<String> forbiddenHeaders = Collections.list(wrapper.getHeaders(JwtUtils.HEADER_USERNAME));
+        assertThat(forbiddenHeaders).isEmpty();
     }
 }

--- a/src/test/java/org/pgsg/user_service/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,128 @@
+package org.pgsg.user_service.auth.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pgsg.user_service.auth.application.dto.info.AuthInfo;
+import org.pgsg.user_service.auth.application.dto.info.SignupInfo;
+import org.pgsg.user_service.auth.application.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.pgsg.user_service.auth.presentation.dto.request.UserLoginRequest;
+import org.pgsg.user_service.auth.presentation.dto.request.UserReissueRequest;
+import org.pgsg.user_service.auth.presentation.dto.request.UserSignupRequest;
+import org.pgsg.user_service.user.presentation.dto.request.ChatTimeRequest;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+@SpringBootTest(properties = "spring.sql.init.mode=never")
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    private final UUID userId = UUID.randomUUID();
+    private final String accessToken = "access.token";
+    private final String refreshToken = "refresh.token";
+
+    @Test
+    @DisplayName("POST /api/v1/auth/login - 성공")
+    void login_Success() throws Exception {
+        // given
+        UserLoginRequest request = new UserLoginRequest("testuser", "password");
+        AuthInfo authInfo = new AuthInfo(accessToken, refreshToken);
+        given(authService.login(any())).willReturn(authInfo);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup - 성공")
+    void signup_Success() throws Exception {
+        // given
+        ChatTimeRequest chatTimeRequest = new ChatTimeRequest(
+                DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)
+        );
+        UserSignupRequest request = new UserSignupRequest(
+                "testuser88", "password123!", "USER", "Tester", "testnick", List.of(chatTimeRequest)
+        );
+
+        SignupInfo signupInfo = new SignupInfo(userId, "testuser88", "testnick", LocalDateTime.now(), userId);
+        given(authService.signup(any())).willReturn(signupInfo);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.data.username").value("testuser88"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/reissue - 성공")
+    void reissue_Success() throws Exception {
+        // given
+        UserReissueRequest request = new UserReissueRequest("old.access.token", "old.refresh.token");
+        AuthInfo authInfo = new AuthInfo(accessToken, refreshToken);
+        given(authService.reissue(any())).willReturn(authInfo);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
+                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/logout - 성공")
+    void logout_Success() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("X-User-Id", userId.toString())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        verify(authService).logout(userId, "Bearer " + accessToken);
+    }
+}

--- a/src/test/java/org/pgsg/user_service/auth/presentation/AuthInternalControllerTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/presentation/AuthInternalControllerTest.java
@@ -1,0 +1,69 @@
+package org.pgsg.user_service.auth.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pgsg.user_service.auth.application.service.TokenService;
+import org.pgsg.user_service.auth.presentation.dto.request.UserVerifyRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "spring.sql.init.mode=never")
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AuthInternalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("POST /internal/v1/auth/verify - 성공: 블랙리스트에 없으면 true 반환")
+    void verifyToken_Valid() throws Exception {
+        // given
+        UserVerifyRequest request = new UserVerifyRequest("valid.token");
+        String requestJson = objectMapper.writeValueAsString(request);
+        given(tokenService.isBlacklisted("valid.token")).willReturn(false);
+
+        // when & then
+        mockMvc.perform(post("/internal/v1/auth/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isVerifiedToken").value(true));
+    }
+
+    @Test
+    @DisplayName("POST /internal/v1/auth/verify - 성공: 블랙리스트에 있으면 false 반환")
+    void verifyToken_Blacklisted() throws Exception {
+        // given
+        UserVerifyRequest request = new UserVerifyRequest("blacklisted.token");
+        String requestJson = objectMapper.writeValueAsString(request);
+        given(tokenService.isBlacklisted("blacklisted.token")).willReturn(true);
+
+        // when & then
+        mockMvc.perform(post("/internal/v1/auth/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isVerifiedToken").value(false));
+    }
+}


### PR DESCRIPTION
### 작업 배경
- 회원/인증 도메인 ci/cd 관련 사전 준비

### 작업 내용
- 인증 도메인 관련 테스트코드 추가 단위 테스트 진행
- 인증 기능 관련 DTO 및 세부 로직 리팩토링
- AuthController의 로그아웃 api 엔드포인트에서 `@AuthenticationPrincipal` 대신 `@RequestHeader`를 사용하도록 수정

### 테스트 여부
- `gradle clean build` 명령어 실행 시 정상적으로 빌드됨을 확인
- 현재까지 구현된 인증 도메인 관련 MVP 기능에 관한 테스트 커버리지 100% 달성(분기 커버리지 기준)
- 인증 도메인의 경우, infrastructure, presentation 계층에 관한 테스트도 진행

    <details>
    
    <summary>인증 도메인 테스트 커버리지 달성률(MVP 구현 기준)</summary>
    
    <img width="1357" height="1161" alt="image" src="https://github.com/user-attachments/assets/ddb2973b-6b0f-41db-a3f9-84dd0d7676b8" />
    
    </details>

### 기타

- 인증 도메인에 관한 실패/예외 발생 케이스 및 회원 도메인에 관한 컨트롤러 테스트까지만 진행하고 회원/인증 도메인에 관한 단위 테스트는 종료 예정
(해당 작업은 별도의 이슈를 생성하여 진행할 예정) 

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그아웃 엔드포인트가 요청 헤더에서 사용자 ID와 액세스 토큰을 직접 읽도록 변경되어 요청 처리 방식이 일관화되었고, 응답이 204 No Content로 반환됩니다.

* **리팩토링**
  * 여러 인증/DTO 타입을 불변(record)으로 전환해 안정성과 명확성을 향상시켰습니다.
  * JWT 처리 흐름의 null 안전성 및 헤더 추가 로직이 개선되었습니다.

* **테스트**
  * 인증, 토큰 발급/검증, 블랙리스트, 필터 및 컨트롤러에 대한 포괄적 단위/통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->