### PR TITLE
fix: ChatTimeRange dayOfWeek 필드 타입 오류 수정 + 회원 도메인 테스트 데이터 추가 가능 여부 확인

### DIFF
--- a/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
@@ -2,6 +2,8 @@ package org.pgsg.user_service.user.domain.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,6 +20,7 @@ import java.time.LocalTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatTimeRange {
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "day_of_week", nullable = false)
 	private DayOfWeek dayOfWeek;
 


### PR DESCRIPTION
### 작업 배경
- 회원 도메인의 채팅가능 시간대의 필드 중 dayOfWeek의 타입 불일치로 인해 테스트 데이터가 추가되지 않는 오류 해결

### 작업 내용
- ChatTimeRange의 dayOfWeek 필드에 `@Enumerated(EnumType.STRING)` 어노테이션 추가

### 테스트 여부
- 회원 도메인 단위 테스트 통과 및 인텔리제이 Data Import 사용 시 로컬 DB에서 테스트 데이터 추가됨을 확인
(인텔리제이의 Data Import 기능 이용 시 csv 파일의 컬럼을 DB 테이블의 컬럼에 맞게 매핑하는 별도의 수작업 진행 필요)

    <details>
    
    <summary>로컬 실행 시 p_user 테이블 테스트 데이터 추가 결과</summary>
    
    <img width="2615" height="1465" alt="image" src="https://github.com/user-attachments/assets/d7ba41b8-8744-427e-b032-1cdcf56f6f20" />
    
    </details>

    <details>
    
    <summary>p_chat_time_range 테이블 테스트 데이터 추가 결과</summary>
    
    <img width="2613" height="1496" alt="image" src="https://github.com/user-attachments/assets/6d3f60ec-925c-4919-a423-2645759c59ac" />
    
    </details>


### 기타
- 데이터 추가 순서는 p_user -> p_chat_time_range 순서로 진행해야 정상적으로 테스트 데이터 추가 가능

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- 예) This closes #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 채팅 시간 범위 데이터 저장 방식 최적화

---

**참고:** 이번 업데이트는 내부 데이터 처리 방식의 개선으로, 사용자 경험에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->