### PR TITLE
[Feat] 지정한 날짜, 시간을 충족하는 특정 회원의 채팅 가능 시간대 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 .env
 **/kafka.server.truststore.jks
+**/csv/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -82,31 +82,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private HttpServletRequest createWrapperWithHeaders(HttpServletRequest request, Claims claims) {
 		HttpRequestHeaderWrapper requestWrapper = new HttpRequestHeaderWrapper(request);
 
-		Optional.ofNullable(claims.getSubject())
-				.ifPresent(id -> requestWrapper.addHeader(JwtUtils.HEADER_USER_ID, id));
-		Optional.ofNullable(claims.get(JwtUtils.CLAIM_USERNAME, String.class))
-				.ifPresent(username -> requestWrapper.addHeader(JwtUtils.HEADER_USERNAME, username));
-		Optional.ofNullable(claims.get(JwtUtils.CLAIM_USER_ROLE, String.class))
-				.ifPresent(roles -> requestWrapper.addHeader(JwtUtils.HEADER_ROLES, roles));
+		requestWrapper.addHeader(JwtUtils.HEADER_USER_ID, claims.getSubject());
+		requestWrapper.addHeader(JwtUtils.HEADER_USERNAME, claims.get(JwtUtils.CLAIM_USERNAME, String.class));
+		requestWrapper.addHeader(JwtUtils.HEADER_ROLES, claims.get(JwtUtils.CLAIM_USER_ROLE, String.class));
+		requestWrapper.addHeader(JwtUtils.HEADER_USER_NAME, encodeValue(claims.get(JwtUtils.CLAIM_NAME, String.class)));
+		requestWrapper.addHeader(JwtUtils.HEADER_USER_NICKNAME, encodeValue(claims.get(JwtUtils.CLAIM_NICKNAME, String.class)));
 
-		// 한글 헤더는 URL 인코딩 처리 (LoginFilter에서 디코딩함)
-		Optional.ofNullable(claims.get(JwtUtils.CLAIM_NAME, String.class))
-				.map(this::encodeValue)
-				.ifPresent(name -> requestWrapper.addHeader(JwtUtils.HEADER_USER_NAME, name));
-
-		Optional.ofNullable(claims.get(JwtUtils.CLAIM_NICKNAME, String.class))
-				.map(this::encodeValue)
-				.ifPresent(nickname -> requestWrapper.addHeader(JwtUtils.HEADER_USER_NICKNAME, nickname));
-
-		// Enabled 여부는 boolean값을 string 타입으로 변환한 값을 저장
-		Optional.ofNullable(claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class))
-				.map(Object::toString)
-				.ifPresent(enabled -> requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled));
+		Boolean enabled = claims.get(JwtUtils.CLAIM_ENABLED, Boolean.class);
+		requestWrapper.addHeader(JwtUtils.HEADER_ENABLED, enabled != null ? enabled.toString() : "false");
 
 		return requestWrapper;
 	}
 
 	private String encodeValue(String value) {
-		return URLEncoder.encode(value, StandardCharsets.UTF_8);
+		return Optional.ofNullable(value)
+				.map(val -> URLEncoder.encode(val, StandardCharsets.UTF_8))
+				.orElse(null);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/application/UserQueryFacade.java
+++ b/src/main/java/org/pgsg/user_service/user/application/UserQueryFacade.java
@@ -2,12 +2,15 @@ package org.pgsg.user_service.user.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.pgsg.user_service.user.application.dto.info.ChatTimeRangeInfo;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
+import org.pgsg.user_service.user.application.dto.query.SearchChatTimeQuery;
 import org.pgsg.user_service.user.application.dto.query.SearchUserQuery;
 import org.pgsg.user_service.user.application.dto.result.UserSearchResult;
 import org.pgsg.user_service.user.domain.exception.UserErrorCode;
 import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
 import org.pgsg.user_service.user.domain.model.User;
 import org.pgsg.user_service.user.domain.model.UserRole;
 import org.pgsg.user_service.user.domain.service.RoleCheck;
@@ -64,5 +67,13 @@ public class UserQueryFacade {
 		User user = userQueryService.getUserForAuth(username);
 
 		return LoginUserDetailInfo.from(user);
+	}
+
+	public List<ChatTimeRangeInfo> getAvailableChatTime(UUID userId, SearchChatTimeQuery chatTimeQuery) {
+		List<ChatTimeRange> chatTimeRanges = userQueryService.getAvailableChatTime(userId, chatTimeQuery);
+
+		return chatTimeRanges.stream()
+				.map(ChatTimeRangeInfo::from)
+				.toList();
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/application/UserQueryService.java
+++ b/src/main/java/org/pgsg/user_service/user/application/UserQueryService.java
@@ -1,9 +1,11 @@
 package org.pgsg.user_service.user.application;
 
 import lombok.RequiredArgsConstructor;
+import org.pgsg.user_service.user.application.dto.query.SearchChatTimeQuery;
 import org.pgsg.user_service.user.application.dto.query.SearchUserQuery;
 import org.pgsg.user_service.user.domain.exception.UserErrorCode;
 import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
 import org.pgsg.user_service.user.domain.model.User;
 import org.pgsg.user_service.user.domain.repository.UserQueryRepository;
 import org.springframework.data.domain.Page;
@@ -11,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 // 트랜잭션 적용구간을 단축
@@ -34,7 +37,14 @@ public class UserQueryService {
 
 	@Transactional(readOnly = true)
 	public Page<User> getUserList(SearchUserQuery searchQuery, Pageable pageable) {
-
 		return userRepository.findAll(searchQuery, pageable);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ChatTimeRange> getAvailableChatTime(UUID userId, SearchChatTimeQuery chatTimeQuery) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new UserServiceException(UserErrorCode.USER_NOT_FOUND));
+
+		return user.findAvailableChatTime(chatTimeQuery.chatDate(), chatTimeQuery.chatTime());
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/application/dto/info/UserDetailInfo.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/info/UserDetailInfo.java
@@ -15,7 +15,7 @@ public record UserDetailInfo(
 		UserRole userRole,
 		String name,
 		String nickname,
-		List<ChatTimeRangeInfo> chatTimeRange,
+		List<ChatTimeRangeInfo> chatTimeRanges,
 
 		LocalDateTime createdAt,
 		UUID createdBy,

--- a/src/main/java/org/pgsg/user_service/user/application/dto/query/SearchChatTimeQuery.java
+++ b/src/main/java/org/pgsg/user_service/user/application/dto/query/SearchChatTimeQuery.java
@@ -1,0 +1,10 @@
+package org.pgsg.user_service.user.application.dto.query;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SearchChatTimeQuery(
+		LocalDate chatDate,
+		LocalTime chatTime
+) {
+}

--- a/src/main/java/org/pgsg/user_service/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/exception/UserErrorCode.java
@@ -35,7 +35,8 @@ public enum UserErrorCode implements ErrorCode {
     UNAUTHORIZED_ROLE_ASSIGNMENT("[user.exception.access-denied.manager-assignment]", "userRole"),
     UNAUTHORIZED_USER_UPDATE("[user.exception.access-denied.user-update]", "userRole"),
     USER_NOT_FOUND("[user.exception.not-found.user]", "userId"),
-    DUPLICATE_USER("[user.exception.conflict.duplicate-user]", "username"),
+    DUPLICATE_USER("[user.exception.conflict.duplicate-user]", "uk_user_username"),
+    DUPLICATE_CHAT_TIME_RANGE("[user.exception.conflict.duplicate-chat-time]", "uk_chat_time_range"),
     USER_ROLE_NOT_FOUND("[user.exception.not-found.user-role]", "userRole"),
     UNAUTHORIZED("[user.exception.unauthorized.invalid-user]", "authentication"),
     SAVE_FAILURE("[user.exception.internal-error.save-user-failure]", "user")

--- a/src/main/java/org/pgsg/user_service/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/exception/UserErrorCode.java
@@ -26,6 +26,9 @@ public enum UserErrorCode implements ErrorCode {
     CHAT_TIME_END_TIME_REQUIRED("[user.validation.user-info-chat-time.end-time-required]", "endTime"),
     INVALID_CHAT_TIME_RANGE("[user.validation.user-info-chat-time.invalid-range]", "chatTimeRanges"),
 
+    CHAT_DATE_REQUIRED("[user.validation.chat-availability.chat-date-required]", "chatDate"),
+    CHAT_TIME_REQUIRED("[user.validation.chat-availability.chat-time-required]", "chatTime"),
+
     // 토큰 재발급 유효성
     REISSUE_ACCESS_TOKEN_REQUIRED("[user.validation.reissue.access-token-required]", "accessToken"),
     REISSUE_REFRESH_TOKEN_REQUIRED("[user.validation.reissue.refresh-token-required]", "refreshToken"),

--- a/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/ChatTimeRange.java
@@ -36,6 +36,13 @@ public class ChatTimeRange {
 		return new ChatTimeRange(dayOfWeek, startTime, endTime);
 	}
 
+	public boolean overlapsWith(ChatTimeRange other) {
+		if (this.dayOfWeek != other.dayOfWeek) {
+			return false;
+		}
+		return this.startTime.isBefore(other.endTime) && other.startTime.isBefore(this.endTime);
+	}
+
 	private static void validateChatTime(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
 		if (dayOfWeek == null) {
 			throw new UserServiceException(UserErrorCode.CHAT_TIME_DAY_OF_WEEK_REQUIRED);

--- a/src/main/java/org/pgsg/user_service/user/domain/model/User.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/User.java
@@ -53,7 +53,7 @@ public class User extends BaseEntity {
 			name = "p_chat_time_range",
 			joinColumns = @JoinColumn(name = "user_id"),
 			uniqueConstraints = @UniqueConstraint(
-					name = "idx_chat_time_range",
+					name = "uk_chat_time_range",
 					columnNames = {"user_id", "day_of_week", "start_time"}
 			)
 	)

--- a/src/main/java/org/pgsg/user_service/user/domain/model/User.java
+++ b/src/main/java/org/pgsg/user_service/user/domain/model/User.java
@@ -10,9 +10,10 @@ import org.pgsg.common.domain.BaseEntity;
 import org.pgsg.user_service.user.domain.exception.UserErrorCode;
 import org.pgsg.user_service.user.domain.exception.UserServiceException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.*;
 
 @Getter
 @Table(
@@ -48,8 +49,15 @@ public class User extends BaseEntity {
 	private String nickname;
 
 	@ElementCollection(fetch = FetchType.LAZY)
-	@CollectionTable(name = "p_chat_time_range", joinColumns = @JoinColumn(name = "user_id"))
-	@OrderBy("dayOfWeek ASC, startTime ASC")
+	@CollectionTable(
+			name = "p_chat_time_range",
+			joinColumns = @JoinColumn(name = "user_id"),
+			uniqueConstraints = @UniqueConstraint(
+					name = "idx_chat_time_range",
+					columnNames = {"user_id", "day_of_week", "start_time"}
+			)
+	)
+	@OrderBy("dayOfWeek ASC, startTime ASC, endTime ASC")
 	private final List<ChatTimeRange> chatTimeRanges = new ArrayList<>();
 
 	@Builder(access = AccessLevel.PRIVATE)
@@ -102,12 +110,28 @@ public class User extends BaseEntity {
 	}
 
 
+	// 회원이 설정한 채팅 가능 시간대 관련
 	public void addChatTimeRangeList(List<ChatTimeRange> chatTimeRanges) {
-		this.chatTimeRanges.addAll(chatTimeRanges);
+		if (chatTimeRanges != null && !chatTimeRanges.isEmpty()) {
+			List<ChatTimeRange> combined = new ArrayList<>(this.chatTimeRanges);
+			combined.addAll(chatTimeRanges);
+			validateRanges(combined);
+			this.chatTimeRanges.addAll(chatTimeRanges);
+		}
+	}
+
+	public List<ChatTimeRange> findAvailableChatTime(LocalDate date, LocalTime time) {
+		return chatTimeRanges.stream()
+				.filter(chatTimeRange -> date != null && chatTimeRange.getDayOfWeek() == date.getDayOfWeek())
+				.filter(chatTimeRange -> time != null
+						&& !time.isBefore(chatTimeRange.getStartTime())
+						&& time.isBefore(chatTimeRange.getEndTime()))
+				.toList();
 	}
 
 	public void updateChatTimeRanges(List<ChatTimeRange> chatTimeRanges) {
 		if (chatTimeRanges != null) {
+			validateRanges(chatTimeRanges);
 			this.chatTimeRanges.clear();
 			this.chatTimeRanges.addAll(chatTimeRanges);
 		}
@@ -115,6 +139,25 @@ public class User extends BaseEntity {
 
 	public void clearChatTimeRanges() {
 		this.chatTimeRanges.clear();
+	}
+
+	private void validateRanges(List<ChatTimeRange> ranges) {
+		if (ranges == null || ranges.isEmpty()) {
+			return;
+		}
+
+		List<ChatTimeRange> sorted = ranges.stream()
+				.sorted(Comparator.comparing(ChatTimeRange::getDayOfWeek)
+						.thenComparing(ChatTimeRange::getStartTime))
+				.toList();
+
+		for (int i = 0; i < sorted.size() - 1; i++) {
+			ChatTimeRange current = sorted.get(i);
+			ChatTimeRange next = sorted.get(i + 1);
+			if (current.overlapsWith(next)) {
+				throw new UserServiceException(UserErrorCode.DUPLICATE_CHAT_TIME_RANGE);
+			}
+		}
 	}
 }
 

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/AbstractCsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/AbstractCsvLoader.java
@@ -1,0 +1,78 @@
+package org.pgsg.user_service.user.infrastructure.loader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractCsvLoader implements CsvLoader {
+
+	protected final JdbcTemplate jdbcTemplate;
+	private final String checkSql;
+	private final String csvPath;
+	private final String insertSql;
+
+	@Override
+	public boolean isLoaded() {
+		try {
+			Integer count = jdbcTemplate.queryForObject(checkSql, Integer.class);
+			return count != null && count > 0;
+		} catch (Exception e) {
+			log.warn("[{}] Could not check table existence or data.", getClass().getSimpleName());
+			return false;
+		}
+	}
+
+	@Override
+	public void load() throws Exception {
+		log.info("[{}] Loading data from {}...", getClass().getSimpleName(), csvPath);
+		ClassPathResource resource = new ClassPathResource(csvPath);
+		if (!resource.exists()) {
+			log.warn("[{}] CSV file not found: {}", getClass().getSimpleName(), csvPath);
+			return;
+		}
+
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+			String line;
+			String header = br.readLine();
+			if (header == null) return;
+			int columnCount = header.split(",", -1).length;
+
+			List<Object[]> batchArgs = new ArrayList<>();
+
+			while ((line = br.readLine()) != null) {
+				String[] data = line.split(",", -1);
+
+				if (data.length != columnCount) {
+					log.warn("[{}] Malformed row skipped (expected {} columns, got {}): {}",
+							getClass().getSimpleName(), columnCount, data.length, line);
+					continue;
+				}
+
+				Object[] row = new Object[columnCount];
+				for (int i = 0; i < columnCount; i++) {
+					String val = data[i].trim();
+					row[i] = val.isEmpty() ? null : val;
+				}
+				batchArgs.add(row);
+
+				if (batchArgs.size() >= 1000) {
+					jdbcTemplate.batchUpdate(insertSql, batchArgs);
+					batchArgs.clear();
+				}
+			}
+			if (!batchArgs.isEmpty()) {
+				jdbcTemplate.batchUpdate(insertSql, batchArgs);
+			}
+		}
+		log.info("[{}] Successfully loaded data from {}.", getClass().getSimpleName(), csvPath);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/ChatTimeCsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/ChatTimeCsvLoader.java
@@ -2,18 +2,24 @@ package org.pgsg.user_service.user.infrastructure.loader;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class ChatTimeCsvLoader extends AbstractCsvLoader {
 
-	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_chat_time_range " +
-			"WHERE user_id = CAST('9107aa7c-a733-4514-8033-89e601a450ab' AS UUID) " +
-			"AND day_of_week = 'THURSDAY' AND start_time = CAST('14:00:00' AS TIME)";
+	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_chat_time_range LIMIT 1";
 	private static final String CSV_PATH = "csv/p_chat_time_range.csv";
-	private static final String INSERT_SQL = "INSERT INTO p_chat_time_range (user_id, day_of_week, start_time, end_time) VALUES (CAST(? AS UUID), ?, CAST(? AS TIME), CAST(? AS TIME))";
+	private static final String INSERT_SQL = "INSERT INTO p_chat_time_range (user_id, day_of_week, start_time, end_time) " +
+			"VALUES (CAST(? AS UUID), ?, CAST(? AS TIME), CAST(? AS TIME)) ON CONFLICT DO NOTHING";
 
 	public ChatTimeCsvLoader(JdbcTemplate jdbcTemplate) {
 		super(jdbcTemplate, CHECK_SQL, CSV_PATH, INSERT_SQL);
+	}
+
+	@Override
+	@Transactional
+	public void load() throws Exception {
+		super.load();
 	}
 
 	@Override

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/ChatTimeCsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/ChatTimeCsvLoader.java
@@ -1,0 +1,23 @@
+package org.pgsg.user_service.user.infrastructure.loader;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatTimeCsvLoader extends AbstractCsvLoader {
+
+	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_chat_time_range " +
+			"WHERE user_id = CAST('9107aa7c-a733-4514-8033-89e601a450ab' AS UUID) " +
+			"AND day_of_week = 'THURSDAY' AND start_time = CAST('14:00:00' AS TIME)";
+	private static final String CSV_PATH = "csv/p_chat_time_range.csv";
+	private static final String INSERT_SQL = "INSERT INTO p_chat_time_range (user_id, day_of_week, start_time, end_time) VALUES (CAST(? AS UUID), ?, CAST(? AS TIME), CAST(? AS TIME))";
+
+	public ChatTimeCsvLoader(JdbcTemplate jdbcTemplate) {
+		super(jdbcTemplate, CHECK_SQL, CSV_PATH, INSERT_SQL);
+	}
+
+	@Override
+	public String getName() {
+		return "Chat Time Range Table (p_chat_time_range)";
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/CsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/CsvLoader.java
@@ -1,0 +1,18 @@
+package org.pgsg.user_service.user.infrastructure.loader;
+
+public interface CsvLoader {
+	/**
+	 * 데이터가 이미 로드되었는지 확인합니다.
+	 */
+	boolean isLoaded();
+
+	/**
+	 * CSV 파일에서 데이터를 읽어 DB에 로드합니다.
+	 */
+	void load() throws Exception;
+
+	/**
+	 * 로더의 이름을 반환합니다 (로그용).
+	 */
+	String getName();
+}

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserCsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserCsvLoader.java
@@ -1,0 +1,22 @@
+package org.pgsg.user_service.user.infrastructure.loader;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserCsvLoader extends AbstractCsvLoader {
+
+	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_user WHERE username = 'user00001'";
+	private static final String CSV_PATH = "csv/p_user.csv";
+	private static final String INSERT_SQL = "INSERT INTO p_user (user_id, username, password, user_role, name, nickname, created_by, created_at, modified_by, modified_at, deleted_by, deleted_at) " +
+			"VALUES (CAST(? AS UUID), ?, ?, ?, ?, ?, CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP))";
+
+	public UserCsvLoader(JdbcTemplate jdbcTemplate) {
+		super(jdbcTemplate, CHECK_SQL, CSV_PATH, INSERT_SQL);
+	}
+
+	@Override
+	public String getName() {
+		return "User Table (p_user)";
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserCsvLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserCsvLoader.java
@@ -2,17 +2,25 @@ package org.pgsg.user_service.user.infrastructure.loader;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class UserCsvLoader extends AbstractCsvLoader {
 
-	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_user WHERE username = 'user00001'";
+	private static final String CHECK_SQL = "SELECT COUNT(*) FROM p_user LIMIT 1";
 	private static final String CSV_PATH = "csv/p_user.csv";
 	private static final String INSERT_SQL = "INSERT INTO p_user (user_id, username, password, user_role, name, nickname, created_by, created_at, modified_by, modified_at, deleted_by, deleted_at) " +
-			"VALUES (CAST(? AS UUID), ?, ?, ?, ?, ?, CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP))";
+			"VALUES (CAST(? AS UUID), ?, ?, ?, ?, ?, CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP), CAST(? AS UUID), CAST(? AS TIMESTAMP)) " +
+			"ON CONFLICT DO NOTHING";
 
 	public UserCsvLoader(JdbcTemplate jdbcTemplate) {
 		super(jdbcTemplate, CHECK_SQL, CSV_PATH, INSERT_SQL);
+	}
+
+	@Override
+	@Transactional
+	public void load() throws Exception {
+		super.load();
 	}
 
 	@Override

--- a/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserServiceCsvDataLoader.java
+++ b/src/main/java/org/pgsg/user_service/user/infrastructure/loader/UserServiceCsvDataLoader.java
@@ -1,0 +1,43 @@
+package org.pgsg.user_service.user.infrastructure.loader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("dev")
+public class UserServiceCsvDataLoader implements CommandLineRunner {
+
+	private final UserCsvLoader userCsvLoader;
+	private final ChatTimeCsvLoader chatTimeCsvLoader;
+
+	@Override
+	public void run(String... args) throws Exception {
+		log.info("[UserServiceCsvDataLoader] Starting orchestrated CSV data load...");
+
+		// 리스트에 추가하는 순서대로 실행 (명시적 순서 보장)
+		List<CsvLoader> loaders = List.of(userCsvLoader, chatTimeCsvLoader);
+
+		for (CsvLoader loader : loaders) {
+			executeLoader(loader);
+		}
+
+		log.info("[UserServiceCsvDataLoader] Orchestrated CSV data load completed.");
+	}
+
+	private void executeLoader(CsvLoader loader) throws Exception {
+		if (!loader.isLoaded()) {
+			log.info("[UserServiceCsvDataLoader] Delegating load task to: {}", loader.getName());
+			loader.load();
+		} else {
+			log.info("[UserServiceCsvDataLoader] Data already exists for: {}. Skipping.", loader.getName());
+		}
+	}
+}
+

--- a/src/main/java/org/pgsg/user_service/user/presentation/UserController.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/UserController.java
@@ -2,7 +2,6 @@ package org.pgsg.user_service.user.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.pgsg.config.security.UserDetailsImpl;
 import org.pgsg.user_service.user.application.UserCommandFacade;
 import org.pgsg.user_service.user.application.UserQueryFacade;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
@@ -17,7 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/src/main/java/org/pgsg/user_service/user/presentation/UserInternalController.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/UserInternalController.java
@@ -1,13 +1,18 @@
 package org.pgsg.user_service.user.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pgsg.user_service.user.application.UserQueryFacade;
+import org.pgsg.user_service.user.application.dto.info.ChatTimeRangeInfo;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
+import org.pgsg.user_service.user.presentation.dto.request.UserChatTimeSearchRequest;
+import org.pgsg.user_service.user.presentation.dto.response.UserChatTimeListResponse;
 import org.pgsg.user_service.user.presentation.dto.response.UserLoginResponse;
 import org.pgsg.user_service.user.presentation.dto.response.UserDetailResponse;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -29,5 +34,13 @@ public class UserInternalController {
 		UserDetailInfo userDetailInfo = userQueryFacade.getUser(userId);
 
 		return UserDetailResponse.from(userDetailInfo);
+	}
+
+	@GetMapping("/{userId}/chat-availability")
+	public UserChatTimeListResponse getAvailableChatTime(
+			@PathVariable("userId") UUID userId, @Valid @ModelAttribute UserChatTimeSearchRequest request) {
+		List<ChatTimeRangeInfo> chatTimeRangeInfoList = userQueryFacade.getAvailableChatTime(userId, request.toQuery());
+
+		return UserChatTimeListResponse.from(chatTimeRangeInfoList);
 	}
 }

--- a/src/main/java/org/pgsg/user_service/user/presentation/dto/request/UserChatTimeSearchRequest.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/dto/request/UserChatTimeSearchRequest.java
@@ -1,0 +1,22 @@
+package org.pgsg.user_service.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.pgsg.user_service.user.application.dto.query.SearchChatTimeQuery;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UserChatTimeSearchRequest(
+		@NotNull(message = "[user.validation.chat-availability.chat-date-required]")
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+		LocalDate chatDate,
+
+		@NotNull(message = "[user.validation.chat-availability.chat-time-required]")
+		@DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+		LocalTime chatTime
+) {
+	public SearchChatTimeQuery toQuery() {
+		return new SearchChatTimeQuery(chatDate(), chatTime());
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/presentation/dto/response/UserChatTimeListResponse.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/dto/response/UserChatTimeListResponse.java
@@ -1,0 +1,13 @@
+package org.pgsg.user_service.user.presentation.dto.response;
+
+import org.pgsg.user_service.user.application.dto.info.ChatTimeRangeInfo;
+
+import java.util.List;
+
+public record UserChatTimeListResponse(
+		List<ChatTimeRangeInfo> chatTimeRanges
+) {
+	public static UserChatTimeListResponse from(List<ChatTimeRangeInfo> chatTimeRanges) {
+		return new UserChatTimeListResponse(chatTimeRanges);
+	}
+}

--- a/src/main/java/org/pgsg/user_service/user/presentation/dto/response/UserDetailResponse.java
+++ b/src/main/java/org/pgsg/user_service/user/presentation/dto/response/UserDetailResponse.java
@@ -14,7 +14,7 @@ public record UserDetailResponse(
 		String name,
 		String nickname,
 		UserRole userRole,
-		List<ChatTimeRangeInfo> chatTimeRange,
+		List<ChatTimeRangeInfo> chatTimeRanges,
 		LocalDateTime createdAt,
 		UUID createdBy,
 		LocalDateTime modifiedAt,
@@ -29,7 +29,7 @@ public record UserDetailResponse(
 				userDetailInfo.name(),
 				userDetailInfo.nickname(),
 				userDetailInfo.userRole(),
-				userDetailInfo.chatTimeRange(),
+				userDetailInfo.chatTimeRanges(),
 
 				userDetailInfo.createdAt(),
 				userDetailInfo.createdBy(),

--- a/src/main/resources/application-user-error.yml
+++ b/src/main/resources/application-user-error.yml
@@ -129,3 +129,18 @@ error:
       code: "U025"
       message: "시작 시간은 종료 시간보다 빨라야 합니다."
       status: 400
+
+    "[user.exception.conflict.duplicate-chat-time]":
+      code: "U026"
+      message: "이미 등록했던 채팅 가능 시간대입니다."
+      status: 409
+
+    "[user.validation.chat-availability.chat-date-required]":
+      code: "U027"
+      message: "회원의 채팅 가능 여부를 조회할 날짜 정보는 필수입니다."
+      status: 400
+
+    "[user.validation.chat-availability.chat-time-required]":
+      code: "U028"
+      message: "회원의 채팅 가능 여부를 조회할 시간 정보는 필수입니다."
+      status: 400

--- a/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/pgsg/user_service/auth/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -222,6 +222,5 @@ class JwtAuthenticationFilterTest {
         // null인 Claim들에 대해서는 헤더가 존재하지 않아야 함 (null 반환)
         assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_NAME)).isNull();
         assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_USER_NICKNAME)).isNull();
-        assertThat(wrappedRequest.getHeader(JwtUtils.HEADER_ENABLED)).isNull();
     }
 }

--- a/src/test/java/org/pgsg/user_service/user/application/UserQueryFacadeTest.java
+++ b/src/test/java/org/pgsg/user_service/user/application/UserQueryFacadeTest.java
@@ -6,16 +6,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.pgsg.user_service.user.application.dto.info.ChatTimeRangeInfo;
 import org.pgsg.user_service.user.application.dto.info.LoginUserDetailInfo;
 import org.pgsg.user_service.user.application.dto.info.UserDetailInfo;
+import org.pgsg.user_service.user.application.dto.query.SearchChatTimeQuery;
 import org.pgsg.user_service.user.application.dto.query.SearchUserQuery;
 import org.pgsg.user_service.user.application.dto.result.UserSearchResult;
 import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
 import org.pgsg.user_service.user.domain.model.User;
 import org.pgsg.user_service.user.domain.model.UserRole;
 import org.pgsg.user_service.user.domain.service.RoleCheck;
 import org.springframework.data.domain.*;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -218,5 +224,27 @@ class UserQueryFacadeTest {
         assertThat(result.username()).isEqualTo(username);
         assertThat(result.password()).isEqualTo("pw");
         verify(userQueryService).getUserForAuth(username);
+    }
+
+    @Test
+    @DisplayName("getAvailableChatTime()은 채팅 가능 시간대 정보 목록을 반환해야 한다")
+    void getAvailableChatTime_returnsChatTimeRangeInfoList() {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate monday = LocalDate.of(2024, 5, 13);
+        LocalTime time = LocalTime.of(10, 0);
+        SearchChatTimeQuery query = new SearchChatTimeQuery(monday, time);
+
+        ChatTimeRange range = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+        given(userQueryService.getAvailableChatTime(userId, query)).willReturn(List.of(range));
+
+        // when
+        List<ChatTimeRangeInfo> result = userQueryFacade.getAvailableChatTime(userId, query);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+        assertThat(result.get(0).startTime()).isEqualTo(LocalTime.of(9, 0));
+        verify(userQueryService).getAvailableChatTime(userId, query);
     }
 }

--- a/src/test/java/org/pgsg/user_service/user/application/UserQueryServiceTest.java
+++ b/src/test/java/org/pgsg/user_service/user/application/UserQueryServiceTest.java
@@ -9,6 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.pgsg.user_service.user.application.dto.query.SearchUserQuery;
 import org.pgsg.user_service.user.domain.exception.UserErrorCode;
 import org.pgsg.user_service.user.domain.exception.UserServiceException;
+import org.pgsg.user_service.user.application.dto.query.SearchChatTimeQuery;
+import org.pgsg.user_service.user.domain.model.ChatTimeRange;
 import org.pgsg.user_service.user.domain.model.User;
 import org.pgsg.user_service.user.domain.model.UserRole;
 import org.pgsg.user_service.user.domain.repository.UserQueryRepository;
@@ -17,6 +19,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -95,5 +100,26 @@ class UserQueryServiceTest {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getAvailableChatTime()은 사용자의 채팅 가능 시간대 목록을 반환해야 한다")
+    void getAvailableChatTime_returnsChatTimeRanges() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = User.create("testuser", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+        user.addChatTimeRangeList(List.of(range));
+
+        LocalDate monday = LocalDate.of(2024, 5, 13);
+        SearchChatTimeQuery query = new SearchChatTimeQuery(monday, LocalTime.of(10, 0));
+
+        given(userQueryRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        List<ChatTimeRange> result = userQueryService.getAvailableChatTime(userId, query);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(range);
     }
 }

--- a/src/test/java/org/pgsg/user_service/user/domain/model/ChatTimeRangeTest.java
+++ b/src/test/java/org/pgsg/user_service/user/domain/model/ChatTimeRangeTest.java
@@ -58,4 +58,42 @@ class ChatTimeRangeTest {
                 .isInstanceOf(UserServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.INVALID_CHAT_TIME_RANGE);
     }
+
+    @Test
+    @DisplayName("overlapsWith()는 요일이 다르면 false를 반환해야 한다")
+    void overlapsWith_returnsFalseForDifferentDays() {
+        ChatTimeRange mon = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0));
+        ChatTimeRange tue = ChatTimeRange.of(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(10, 0));
+
+        assertThat(mon.overlapsWith(tue)).isFalse();
+    }
+
+    @Test
+    @DisplayName("overlapsWith()는 같은 요일이고 시간이 겹치면 true를 반환해야 한다")
+    void overlapsWith_returnsTrueForOverlappingTimes() {
+        ChatTimeRange base = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        // 부분 겹침 (앞쪽)
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0)))).isTrue();
+        // 부분 겹침 (뒤쪽)
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(11, 0), LocalTime.of(13, 0)))).isTrue();
+        // 포함 관계
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 30), LocalTime.of(11, 30)))).isTrue();
+        // 동일 범위
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(12, 0)))).isTrue();
+    }
+
+    @Test
+    @DisplayName("overlapsWith()는 같은 요일이라도 시간이 겹치지 않으면 false를 반환해야 한다")
+    void overlapsWith_returnsFalseForNonOverlappingTimes() {
+        ChatTimeRange base = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        // 완전히 앞쪽
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(8, 0), LocalTime.of(9, 0)))).isFalse();
+        // 완전히 뒤쪽
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(14, 0)))).isFalse();
+        // 경계선에서 만남 (겹치지 않음)
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0)))).isFalse();
+        assertThat(base.overlapsWith(ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(12, 0), LocalTime.of(13, 0)))).isFalse();
+    }
 }

--- a/src/test/java/org/pgsg/user_service/user/domain/model/UserTest.java
+++ b/src/test/java/org/pgsg/user_service/user/domain/model/UserTest.java
@@ -1,10 +1,12 @@
 package org.pgsg.user_service.user.domain.model;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -114,6 +116,85 @@ class UserTest {
         user.updateChatTimeRanges(null); // null 시 유지
         assertThat(user.getChatTimeRanges()).hasSize(1).containsExactly(range2);
     }
+
+    @Test
+    @DisplayName("중복되지 않는 시작 시간을 가졌더라도 겹치는 시간대는 예외를 던져야 한다")
+    void addChatTimeRangeList_throwsExceptionForOverlappingRanges() {
+        User user = User.create("user", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range1 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+        ChatTimeRange range2 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        Assertions.assertThatThrownBy(() -> user.addChatTimeRangeList(List.of(range1, range2)))
+                .isInstanceOf(org.pgsg.user_service.user.domain.exception.UserServiceException.class);
+    }
+
+    @Test
+    @DisplayName("updateChatTimeRanges() 호출 시 기존 시간대를 대체하므로 시작 시간이 같아도 성공해야 한다")
+    void updateChatTimeRanges_succeedsWhenReplacingWithSameStartTime() {
+        User user = User.create("user", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range1 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0));
+        user.addChatTimeRangeList(List.of(range1));
+
+        ChatTimeRange range2 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+
+        org.assertj.core.api.Assertions.assertThatCode(() -> user.updateChatTimeRanges(List.of(range2)))
+                .doesNotThrowAnyException();
+        assertThat(user.getChatTimeRanges()).hasSize(1).containsExactly(range2);
+    }
+
+    @Test
+    @DisplayName("findAvailableChatTime()은 날짜와 시간에 맞는 채팅 가능 시간대를 반환해야 한다")
+    void findAvailableChatTime_returnsMatchingRanges() {
+        User user = User.create("user", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range1 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+        ChatTimeRange range2 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(14, 0), LocalTime.of(16, 0));
+        user.addChatTimeRangeList(List.of(range1, range2));
+
+        // 월요일 10시 -> range1 반환
+        LocalDate monday = LocalDate.of(2024, 5, 13); // 2024-05-13은 월요일
+        List<ChatTimeRange> result1 = user.findAvailableChatTime(monday, LocalTime.of(10, 0));
+        assertThat(result1).hasSize(1).containsExactly(range1);
+
+        // 월요일 11시 -> 끝나는 시간은 포함 안 됨 (empty)
+        List<ChatTimeRange> result2 = user.findAvailableChatTime(monday, LocalTime.of(11, 0));
+        assertThat(result2).isEmpty();
+
+        // 화요일 10시 -> 요일 불일치 (empty)
+        LocalDate tuesday = LocalDate.of(2024, 5, 14);
+        List<ChatTimeRange> result3 = user.findAvailableChatTime(tuesday, LocalTime.of(10, 0));
+        assertThat(result3).isEmpty();
+
+        // 입력값이 null인 경우 -> (empty)
+        assertThat(user.findAvailableChatTime(null, LocalTime.of(10, 0))).isEmpty();
+        assertThat(user.findAvailableChatTime(monday, null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("validateRanges()는 인접한 시간대가 겹치지 않으면(경계선 포함) 성공해야 한다")
+    void validateRanges_succeedsForNonOverlappingConsecutiveRanges() {
+        User user = User.create("user", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range1 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0));
+        ChatTimeRange range2 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(11, 0));
+
+        // 10:00에 딱 붙어 있는 경우 허용되어야 함
+        Assertions.assertThatCode(() -> user.addChatTimeRangeList(List.of(range1, range2)))
+                .doesNotThrowAnyException();
+        assertThat(user.getChatTimeRanges()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("validateRanges()는 정렬되지 않은 상태로 들어와도 정렬 후 겹침을 체크해야 한다")
+    void validateRanges_checksOverlapsAfterSorting() {
+        User user = User.create("user", "pw", UserRole.USER, "이름", "닉");
+        ChatTimeRange range1 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(15, 0), LocalTime.of(17, 0));
+        ChatTimeRange range2 = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(11, 0));
+        ChatTimeRange overlapping = ChatTimeRange.of(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        // [9-11]과 [10-12]가 겹침 (순서 상관 없이 검증되어야 함)
+        Assertions.assertThatThrownBy(() -> user.addChatTimeRangeList(List.of(range1, range2, overlapping)))
+                .isInstanceOf(org.pgsg.user_service.user.domain.exception.UserServiceException.class);
+    }
+
 
     @Test
     @DisplayName("delete() 호출 시 사용자가 비활성화되어야 한다")


### PR DESCRIPTION
### 작업 배경
- 회원의 채팅 가능 시간대 관련 미구현된 조회 기능 추가

### 작업 내용

- ChatTimeRange에 관한 중복 방지 조건 지정
- 지정한 날짜, 시간을 충족하는 특정 회원의 채팅 가능 시간대 조회 기능 구현 및 테스트코드 추가
  - 회원의 채팅 가능 시간대가 선택한 날짜에 해당하는 요일과 같고 지정한 시간이 회원이 설정한 채팅 가능 시간 범위에 포함되는 경우에는 조건을 충족
  
- 회원 도메인 전용 CsvDataLoader 구현
  - CsvLoader 인터페이스와 AbstractCsvLoader는 다른 도메인에서도 공통적으로 활용 가능
  - UserServiceCsvDataLoader, UserCsvLoader, ChatTimeCsvLoader는 회원 도메인 전용
    - UserServiceCsvDataLoader: CsvLoader 구현 클래스들 간 실행 순서 지정
    - UserCsvLoader, ChatTimeCsvLoader: .csv 파일로 생성한 테스트 데이터를 저장할 각각의 DB 테이블에 대응됨
    - 작업을 진행한 .csv 파일은 `src/main/resources` 폴더에 저장 후 해당 저장 경로를 `.gitignore` 에 추가하여 외부 노출 방지

### 테스트 여부
- `gradle clean build` 수행 시 정상적으로 빌드 완료
- postman 테스트를 통해 구현한 기능이 동작함을 확인

    <details>
    
    <summary>지정한 날짜, 시간을 충족하는 특정 회원의 채팅 가능 시간대 조회</summary>
    
    <img width="1709" height="1477" alt="image" src="https://github.com/user-attachments/assets/2fa67898-26bf-469f-97f5-98618449e3b8" />
    
    </details>

    <details>
    
    <summary>회원 도메인 전용 커스텀 CsvDataLoader 실행 로그(docker 컨테이너 기준)</summary>
    
    ```
    2026-05-08T17:36:43.989Z  INFO 1 --- [user-service] [foReplicator-%d] com.netflix.discovery.DiscoveryClient    : DiscoveryClient_USER-SERVICE/user-service:user-service:8081 - registration status: 204
    2026-05-08T17:36:44.228Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.CsvDataLoader           : [CsvDataLoader] Starting orchestrated CSV data load...
    2026-05-08T17:36:44.252Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.CsvDataLoader           : [CsvDataLoader] Delegating load task to: User Table (p_user)
    2026-05-08T17:36:44.252Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.AbstractCsvLoader       : [UserCsvLoader] Loading data from csv/p_user.csv...
    2026-05-08T17:36:44.968Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.AbstractCsvLoader       : [UserCsvLoader] Successfully loaded data from csv/p_user.csv.
    2026-05-08T17:36:44.970Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.CsvDataLoader           : [CsvDataLoader] Delegating load task to: Chat Time Range Table (p_chat_time_range)
    2026-05-08T17:36:44.970Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.AbstractCsvLoader       : [ChatTimeCsvLoader] Loading data from csv/p_chat_time_range.csv...
    2026-05-08T17:36:46.570Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.AbstractCsvLoader       : [ChatTimeCsvLoader] Successfully loaded data from csv/p_chat_time_range.csv.
    2026-05-08T17:36:46.571Z  INFO 1 --- [user-service] [           main] o.p.u.u.i.loader.CsvDataLoader           : [CsvDataLoader] Orchestrated CSV data load completed.
    ```
    
    </details>

### 기타
- 

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #46 

 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자별 특정 날짜·시간 기준 채팅 가능 시간 조회 API 추가

* **개선 사항**
  * 채팅 시간 범위의 중복 검사 및 겹침 감지 강화
  * 경계 시점(끝시간 == 시작시간) 처리 명확화

* **오류/검증**
  * 채팅 조회용 날짜·시간 필수 검증 및 중복 범위 충돌에 대한 오류 코드 추가

* **테스트**
  * 채팅 시간 겹침 로직 및 조회 기능에 대한 단위 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->