### PR TITLE
[FIX] 모니터링 api 차단 문제 해결

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,5 @@ KAFKA_BOOTSTRAP_SERVERS=kafka1:9092,kafka2:9092
 # 주의: SSL 파일은 컨테이너 내 절대 경로(/app/ssl/...)로 지정해야 합니다.
 SPRING_KAFKA_SSL_TRUST_STORE_LOCATION=/app/ssl/kafka.server.truststore.jks
 TRUST_STORE_PASSWORD=your_truststore_password
+
+ZIPKIN_ENDPOINT=http://localhost:9411/api/v2/spans

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -262,13 +262,13 @@ jobs:
                 sudo env IMAGE_TAG=\"$ROLLBACK_TAG\" AR_IMAGE_PATH=\"${{ env.AR_IMAGE_PATH }}\" docker compose -f docker-compose.prod.yaml pull
                 sudo env IMAGE_TAG=\"$ROLLBACK_TAG\" AR_IMAGE_PATH=\"${{ env.AR_IMAGE_PATH }}\" docker compose -f docker-compose.prod.yaml up -d
 
-                for i in \$(seq 1 18); do
+                for i in \$(seq 1 $HEALTH_RETRIES); do
                   if curl -sf http://localhost:8081/actuator/health \
                       | grep -q '\"status\":\"UP\"'; then
                     echo \"Rollback container UP (attempt \$i)\"
                     exit 0
                   fi
-                  sleep 10
+                  sleep $HEALTH_INTERVAL
                 done
 
                 echo 'Rollback container did not become healthy.'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ env:
   AR_IMAGE_PATH: ${{ vars.AR_IMAGE_PATH }}
   WORK_DIR: /opt/user-service
   HEALTH_RETRIES: 30
-  HEALTH_INTERVAL: 10
+  HEALTH_INTERVAL: 5
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -165,6 +165,12 @@ jobs:
             --zone="${{ matrix.zone }}" \
             --project="$GCP_PROJECT" \
             --tunnel-through-iap
+          
+          gcloud compute scp deploy/promtail-config.yml \
+            ${{ matrix.vm }}:/tmp/promtail-config.yml \
+            --zone="${{ matrix.zone }}" \
+            --project="$GCP_PROJECT" \
+            --tunnel-through-iap
 
       - name: Deploy and verify on ${{ matrix.vm }}
         id: deploy_run
@@ -186,6 +192,7 @@ jobs:
 
               sudo mkdir -p $WORK_DIR
               sudo mv /tmp/docker-compose.prod.yaml $WORK_DIR/docker-compose.prod.yaml
+              sudo mv /tmp/promtail-config.yml $WORK_DIR/promtail-config.yml
               cd $WORK_DIR
           
               test -f .env || { echo '.env not found in $WORK_DIR'; exit 1; }

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,9 @@ repositories {
 
 dependencies {
 
-	implementation 'org.pgsg:common:0.2.10-SNAPSHOT'
+	implementation 'org.pgsg:common:0.3.2-SNAPSHOT'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	// postgres - UUID 네이티브 타입 지원
 	runtimeOnly 'org.postgresql:postgresql'

--- a/deploy/docker-compose.prod.yaml
+++ b/deploy/docker-compose.prod.yaml
@@ -19,7 +19,7 @@ services:
     volumes:
       - /opt/user-service/promtail-config.yml:/etc/promtail/config.yml
       - /opt/user-service/logs:/logs
-    command: run --config.format=promtail /etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
     networks:
       - pgsg-network
 

--- a/deploy/docker-compose.prod.yaml
+++ b/deploy/docker-compose.prod.yaml
@@ -12,6 +12,17 @@ services:
     networks:
       - pgsg-network
 
+  promtail:
+    image: grafana/promtail:2.9.1
+    container_name: user-service-promtail
+    restart: always
+    volumes:
+      - /opt/user-service/promtail-config.yml:/etc/promtail/config.yml
+      - /opt/user-service/logs:/logs
+    command: run --config.format=promtail /etc/promtail/config.yml
+    networks:
+      - pgsg-network
+
 networks:
   pgsg-network:
     external: true

--- a/deploy/promtail-config.yml
+++ b/deploy/promtail-config.yml
@@ -1,0 +1,14 @@
+server:
+  http_listen_port: 9080
+
+clients:
+  - url: http://34.47.69.9:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: user-service
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: user-service
+          __path__: /logs/*.log

--- a/deploy/promtail-config.yml
+++ b/deploy/promtail-config.yml
@@ -2,7 +2,7 @@ server:
   http_listen_port: 9080
 
 clients:
-  - url: http://34.47.69.9:3100/loki/api/v1/push
+  - url: ${LOKI_URL:-http://loki:3100/loki/api/v1/push}
 
 scrape_configs:
   - job_name: user-service

--- a/src/main/java/org/pgsg/user_service/auth/infrastructure/security/config/UserSecurityConfig.java
+++ b/src/main/java/org/pgsg/user_service/auth/infrastructure/security/config/UserSecurityConfig.java
@@ -43,7 +43,7 @@ public class UserSecurityConfig implements SecurityConfig {
                         .requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/auth/reissue").permitAll()
                         .requestMatchers("/internal/v1/**").permitAll()
                         .requestMatchers("/favicon.ico", "/error").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 // LoginFilter는 회원 아이디, 비밀번호 검증 이전에 먼저 실행 -> 이미 SecurityContext에 등록된 사용자 정보가 있으면 자동 통과

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,4 +57,4 @@ management:
       probability: 1.0
   zipkin:
     tracing:
-      endpoint: http://xn--vm-3ip-z01x226e:9411/api/v2/spans
+      endpoint: http://34.47.69.9:9411/api/v2/spans

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,12 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://xn--vm-3ip-z01x226e:9411/api/v2/spans

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ eureka:
 management:
   tracing:
     sampling:
-      probability: 1.0
+      probability: 0.1
   zipkin:
     tracing:
-      endpoint: http://34.47.69.9:9411/api/v2/spans
+      endpoint: ${ZIPKIN_ENDPOINT:http://localhost:9411/api/v2/spans}


### PR DESCRIPTION
### 작업 배경
- 모니터링 api 호출 시 401 에러 발생 문제 해결

### 작업 내용
- UserSecurityConfig의 설정 수정 
- zipkin 서버 연동 관련 설정 추가
  - deploy/promtail-config.yml 파일도 원격 서버에 배포되도록 deploy.yaml의 배포 워크플로우 수정
  - application.yaml 파일에 Zipkin 관련 설정 추가
  - user-service 원격 VM 인스턴스에 zipkin, loki 관련 환경변수 추가
  - deploy/docker-compose.prod.yaml 파일에 promtail 관련 설정 추가
  - deploy/promtail-config.yml 파일 추가

### 테스트 여부
- 현재 PR에서 UserSecurityConfig 수정사항을 반영하기 위한 재배포부터 우선 진행
  - user-service의 모니터링 기능 연동 확인
  - user-service의 Zipkin 연동 여부 확인

<details>

<summary>user-service Prometheus 연동 확인</summary>

<img width="2842" height="1628" alt="image" src="https://github.com/user-attachments/assets/4ced2f05-f247-4a01-b666-8a635d12fa31" />

</details>

<details>

<summary>user-service Zipkin 연동 확인</summary>

<img width="2878" height="1535" alt="image" src="https://github.com/user-attachments/assets/283d966e-4b00-4a12-9a53-de68aa8b52e9" />

</details>

### 기타
- 우선은 UserSecurityConfig의 보안 설정 수정사항부터 먼저 반영하기 위해 해당 사항에 관한 재배포만 먼저 수행했습니다.
- 이후 현재 PR에서 로그 수집 관련 설정까지 반영한 다음 PR merge를 진행할 예정입니다. 

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #54 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모니터링 엔드포인트에 대한 비인증 액세스 범위를 확대하도록 보안 설정을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/user-service/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->